### PR TITLE
Complete to/from neo-eulerian/quaternion methods and improve readability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,13 @@ Added
   use when plotting vectors.
 - Two offsets in the stereographic coordinates (X, Y) can be given to
   ``StereographicPlot.text()`` to offset text coordinates.
+- Creating quaternions from neo-eulerian vectors via new class methods
+  ``from_rodrigues()`` and ``from_homochoric()``, replacing the now deprecated
+  ``from_neo_euler()``. ``from_rodrigues()`` accepts an angle parameter to allow passing
+  Rodrigues-Frank vectors.
+- Creating neo-eulerian vectors from quaternions via new methods ``to_axes_angles()``,
+  ``to_rodrigues()`` and ``to_homochoric()``. Rodrigues-Frank vectors can be returned
+  from ``to_rodrigues()`` by passing ``frank=True``.
 
 Changed
 -------
@@ -24,6 +31,9 @@ Changed
 
 Deprecated
 ----------
+- Creating quaternions from neo-eulerian vectors via ``from_neo_euler()`` is deprecated
+  and will be removed in v0.13. Use the existing ``from_axes_angles()`` and the new
+  ``from_rodrigues()`` and ``from_homochoric()`` instead.
 
 Removed
 -------

--- a/doc/user/bibliography.bib
+++ b/doc/user/bibliography.bib
@@ -17,7 +17,6 @@
 	issn = {10445803},
 	journal = {Materials Characterization},
 	keywords = {Crystal orientation, Electron backscatter diffraction, Electron microscopy, Texture, ebsd, indexing},
-	mendeley-tags = {ebsd,indexing},
 	pages = {113–126},
 	publisher = {The Authors},
 	title = {{Tutorial: Crystal orientations and EBSD - Or which way is up?}},
@@ -31,20 +30,32 @@
 	year = {2003},
 	isbn = {0-521-62006-6}
 }
+@article{frank1988orientation,
+	author   = {Frank, Frederick Charles},
+	title    = {{Orientation mapping}},
+	doi      = {10.1007/BF02649253},
+	issn     = {0360-2133},
+	number   = {3},
+	pages    = {403–408},
+	volume   = {19},
+	isbn     = {9780444537706},
+	journal  = {Metallurgical Transactions A},
+	year     = {1988},
+}
 @book{lavalle2006planning,
-  title = {Planning algorithms},
-  author = {LaValle, Steven M},
-  year = {2006},
-  publisher = {Cambridge university press},
-  url = {http://planning.cs.uiuc.edu/node198.html}
+    title = {Planning algorithms},
+    author = {LaValle, Steven M},
+    year = {2006},
+    publisher = {Cambridge university press},
+    url = {http://planning.cs.uiuc.edu/node198.html}
 }
 @book{kirk1995graphics,
-  title = {Graphics Gems III},
-  editor = {Kirk, David},
-  publisher = {Elsevier},
-  url = {http://inis.jinr.ru/sl/vol1/CMC/Graphics_Gems_3,ed_D.Kirk.pdf},
-  year = {1995},
-  isbn = {0-12-409673-5}
+    title = {Graphics Gems III},
+    editor = {Kirk, David},
+    publisher = {Elsevier},
+    url = {http://inis.jinr.ru/sl/vol1/CMC/Graphics_Gems_3,ed_D.Kirk.pdf},
+    year = {1995},
+    isbn = {0-12-409673-5}
 }
 @article{krakow2017onthree,
 	author = {Krakow, Robert and Bennett, Robbie J and Johnstone, Duncan N and Vukmanovic, Zoja and Solano-Alvarez, Wilberth and Lainé, Steven J and Einsle, Joshua F and Midgley, Paul A and Rae, Catherine M F and Hielscher, Ralf},
@@ -82,7 +93,6 @@
 	doi = {10.1107/S1600576716012942},
 	issn = {16005767},
 	journal = {Journal of Applied Crystallography},
-	keywords = {color coding, electron backscatter diffraction, orientation description, symmetry groups},
 	number = {5},
 	pages = {1786–1802},
 	title = {{Orientations - Perfectly colored}},
@@ -140,11 +150,11 @@
 	url = {https://www.degruyter.com/document/doi/10.3139/ijmr-2004-0043},
 	volume = {95},
 	year = {2004},
-	}
+}
 @article{weisstein2005spherical,
-  title={Spherical coordinates},
-  author={Weisstein, Eric W},
-  journal={https://mathworld. wolfram. com/},
-  year={2005},
-  publisher={Wolfram Research, Inc.}
+	title={Spherical coordinates},
+    author={Weisstein, Eric W},
+    journal={https://mathworld. wolfram. com/},
+    year={2005},
+    publisher={Wolfram Research, Inc.}
 }

--- a/orix/quaternion/_conversions.py
+++ b/orix/quaternion/_conversions.py
@@ -27,6 +27,8 @@ for users.
     code. We may change the API at any time with no warning.
 """
 
+from typing import Tuple
+
 import numba as nb
 import numpy as np
 
@@ -89,27 +91,29 @@ def get_pyramid_2d(xyz: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_scalars = xyz.shape[0]
-    pyramids = np.zeros(n_scalars, dtype=np.int64)
-    for i in nb.prange(n_scalars):
+    n = xyz.shape[0]
+    pyramids = np.zeros(n, dtype=np.int64)
+    for i in nb.prange(n):
         pyramids[i] = get_pyramid_single(xyz[i])
     return pyramids
 
 
 def get_pyramid(xyz: np.ndarray) -> np.ndarray:
-    """n-dimensional wrapper for get_pyramid_2d, see the docstring of
+    """N-dimensional wrapper for get_pyramid_2d, see the docstring of
     that function.
     """
-    n_xyz = np.prod(xyz.shape[:-1])
-    xyz2d = xyz.astype(np.float64).reshape(n_xyz, 3)
-    pyramids = get_pyramid_2d(xyz2d).reshape(n_xyz)
+    xyz2d = xyz.astype(np.float64)
+    xyz2d = xyz2d.reshape(-1, 3)
+
+    pyramids = get_pyramid_2d(xyz2d).ravel()
+
     return pyramids
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
 def cu2ho_single(cu: np.ndarray) -> np.ndarray:
-    """Conversion from a single set of cubochoric coordinates to
-    un-normalized homochoric coordinates :cite:`singh2016orientation`.
+    """Convert a single set of cubochoric coordinates to un-normalized
+    homochoric coordinates :cite:`singh2016orientation`.
 
     Parameters
     ----------
@@ -187,7 +191,7 @@ def cu2ho_single(cu: np.ndarray) -> np.ndarray:
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def cu2ho_2d(cu: np.ndarray) -> np.ndarray:
-    """Conversion from multiple cubochoric coordinates to un-normalized
+    """Convert multiple cubochoric coordinates to un-normalized
     homochoric coordinates :cite:`singh2016orientation`.
 
     Parameters
@@ -215,15 +219,18 @@ def cu2ho(cu: np.ndarray) -> np.ndarray:
     """N-dimensional wrapper for cu2ho_2d, see the docstring of that
     function.
     """
-    n_cu = np.prod(cu.shape[:-1])
-    cu2d = cu.astype(np.float64).reshape(n_cu, 3)
-    ho = cu2ho_2d(cu2d).reshape(cu.shape)
+    cu2d = cu.astype(np.float64)
+    cu2d = cu2d.reshape(-1, 3)
+
+    ho = cu2ho_2d(cu2d)
+    ho = ho.reshape(cu.shape)
+
     return ho
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
 def ho2ax_single(ho: np.ndarray) -> np.ndarray:
-    """Conversion from a single set of homochoric coordinates to an
+    """Convert a single set of homochoric coordinates to an
     un-normalized axis-angle pair :cite:`rowenhorst2015consistent`.
 
     Parameters
@@ -241,7 +248,7 @@ def ho2ax_single(ho: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    # Constants stolen directly from EMsoft
+    # Constants copied from EMsoft
     # fmt: off
     fit_parameters = np.array([
          0.9999999999999968,     -0.49999999999986866,     -0.025000000000632055,
@@ -249,8 +256,8 @@ def ho2ax_single(ho: np.ndarray) -> np.ndarray:
         -0.00004985822229871769, -0.000014164962366386031, -1.9000248160936107e-6,
         -5.72184549898506e-6,     7.772149920658778e-6,    -0.00001053483452909705,
          9.528014229335313e-6,   -5.660288876265125e-6,     1.2844901692764126e-6,
-         1.1255185726258763e-6,  -1.3834391419956455e-6,   7.513691751164847e-7,
-        -2.401996891720091e-7,    4.386887017466388e-8,   -3.5917775353564864e-9
+         1.1255185726258763e-6,  -1.3834391419956455e-6,    7.513691751164847e-7,
+        -2.401996891720091e-7,    4.386887017466388e-8,    -3.5917775353564864e-9
     ])
     # fmt: on
     ho_magnitude = np.sum(ho**2)
@@ -274,7 +281,7 @@ def ho2ax_single(ho: np.ndarray) -> np.ndarray:
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def ho2ax_2d(ho: np.ndarray) -> np.ndarray:
-    """Conversion from multiple homochoric coordinates to un-normalized
+    """Convert multiple homochoric coordinates to un-normalized
     axis-angle pairs :cite:`rowenhorst2015consistent`.
 
     Parameters
@@ -292,9 +299,9 @@ def ho2ax_2d(ho: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_vectors = ho.shape[0]
-    ax = np.zeros((n_vectors, 4), dtype=np.float64)
-    for i in nb.prange(n_vectors):
+    n = ho.shape[0]
+    ax = np.zeros((n, 4), dtype=np.float64)
+    for i in nb.prange(n):
         ax[i] = ho2ax_single(ho[i])
     return ax
 
@@ -303,16 +310,19 @@ def ho2ax(ho: np.ndarray) -> np.ndarray:
     """N-dimensional wrapper for ho2ax_2d, see the docstring of that
     function.
     """
-    n_ho = np.prod(ho.shape[:-1])
-    ho2d = ho.astype(np.float64).reshape(n_ho, 3)
-    ho = ho2ax_2d(ho2d).reshape(ho.shape[:-1] + (4,))
-    return ho
+    ho2d = ho.astype(np.float64)
+    ho2d = ho2d.reshape(-1, 3)
+
+    ax = ho2ax_2d(ho2d)
+    ax = ax.reshape(ho.shape[:-1] + (4,))
+
+    return ax
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
 def ax2ro_single(ax: np.ndarray) -> np.ndarray:
-    """Conversion from a single angle-axis pair to an un-normalized
-    Rodrigues vector :cite:`rowenhorst2015consistent`.
+    """Convert a single angle-axis pair to an un-normalized Rodrigues
+    vector :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -335,14 +345,13 @@ def ax2ro_single(ax: np.ndarray) -> np.ndarray:
         ro[2] = 1
     else:
         ro[:3] = ax[:3]
-        # Need to deal with the 180 degree case.
-        # a cutoff of 1e-3 will give a maximum rodrigues magnitude of
-        # approximately 2000. raising it higher can cause rounding errors
-        # during conversions to other rotation representations. If there
-        # is ever a situation where this error must be smaller, the accuracy
-        # of the test values for homochoric and axis_angle in
-        # test_conversions.py must be increased to more than 4 signifigant
-        # figures.
+        # Need to deal with the 180 degree case. A cutoff of 0.001 will
+        # give a maximum Rodrigues magnitude of approximately 2000.
+        # Raising it higher can cause rounding errors during conversions
+        # to other rotation representations. If there is ever a
+        # situation where this error must be smaller, the accuracy of
+        # the test values for Homochoric and axis/angle in the tests
+        # must be increased to more than 4 significant figures.
         if np.abs(angle - np.pi) < 1e-3:
             ro[3] = np.inf
         else:
@@ -352,8 +361,8 @@ def ax2ro_single(ax: np.ndarray) -> np.ndarray:
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def ax2ro_2d(ax: np.ndarray) -> np.ndarray:
-    """Conversion from multiple axis-angle pairs to un-normalized
-    Rodrigues vectors :cite:`rowenhorst2015consistent`.
+    """Convert multiple axis-angle pairs to un-normalized Rodrigues
+    vectors :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -370,8 +379,9 @@ def ax2ro_2d(ax: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    ro = np.zeros_like(ax, dtype=np.float64)
-    for i in nb.prange(ax.shape[0]):
+    n = ax.shape[0]
+    ro = np.zeros((n, 4), dtype=np.float64)
+    for i in nb.prange(n):
         ro[i] = ax2ro_single(ax[i])
     return ro
 
@@ -380,16 +390,19 @@ def ax2ro(ax: np.ndarray) -> np.ndarray:
     """N-dimensional wrapper for ax2ro_2d, see the docstring of that
     function.
     """
-    n_ax = np.prod(ax.shape[:-1])
-    ax2d = ax.astype(np.float64).reshape(n_ax, 4)
-    ro = ax2ro_2d(ax2d).reshape(ax.shape)
+    ax2d = ax.astype(np.float64)
+    ax2d = ax2d.reshape(-1, 4)
+
+    ro = ax2ro_2d(ax2d)
+    ro = ro.reshape(ax.shape)
+
     return ro
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
 def ro2ax_single(ro: np.ndarray) -> np.ndarray:
-    """Conversion from a single Rodrigues vector to an un-normalized
-    axis-angle pair :cite:`rowenhorst2015consistent`.
+    """Convert a single Rodrigues vector to an un-normalized axis-angle
+    pair :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -417,8 +430,8 @@ def ro2ax_single(ro: np.ndarray) -> np.ndarray:
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def ro2ax_2d(ro: np.ndarray) -> np.ndarray:
-    """Conversion from multiple Rodrigues vectors to un-normalized
-    axis-angle pairs :cite:`rowenhorst2015consistent`.
+    """Convert multiple Rodrigues vectors to un-normalized axis-angle
+    pairs :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -435,9 +448,9 @@ def ro2ax_2d(ro: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_vectors = ro.shape[0]
-    ax = np.zeros((n_vectors, 4), dtype=np.float64)
-    for i in nb.prange(n_vectors):
+    n = ro.shape[0]
+    ax = np.zeros((n, 4), dtype=np.float64)
+    for i in nb.prange(n):
         ax[i] = ro2ax_single(ro[i])
     return ax
 
@@ -446,16 +459,19 @@ def ro2ax(ro: np.ndarray) -> np.ndarray:
     """N-dimensional wrapper for ro2ax_2d, see the docstring of that
     function.
     """
-    n_ro = np.prod(ro.shape[:-1])
-    ro2d = ro.astype(np.float64).reshape(n_ro, 4)
-    ax = ro2ax_2d(ro2d).reshape(ro.shape)
+    ro2d = ro.astype(np.float64)
+    ro2d = ro2d.reshape(-1, 4)
+
+    ax = ro2ax_2d(ro2d)
+    ax = ax.reshape(ro.shape)
+
     return ax
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
 def ax2qu_single(ax: np.ndarray) -> np.ndarray:
-    """Conversion from a single axis-angle pair to an un-normalized
-    quaternion :cite:`rowenhorst2015consistent`.
+    """Convert a single axis-angle pair to a unit quaternion
+    :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -485,8 +501,8 @@ def ax2qu_single(ax: np.ndarray) -> np.ndarray:
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def ax2qu_2d(ax: np.ndarray) -> np.ndarray:
-    """Conversion from multiple axis-angle pairs to un-normalized
-    quaternions :cite:`rowenhorst2015consistent`.
+    """Convert multiple axis-angle pairs to unit quaternions
+    :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -503,9 +519,9 @@ def ax2qu_2d(ax: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_vectors = ax.shape[0]
-    qu = np.zeros((n_vectors, 4), dtype=np.float64)
-    for i in nb.prange(n_vectors):
+    n = ax.shape[0]
+    qu = np.zeros((n, 4), dtype=np.float64)
+    for i in nb.prange(n):
         qu[i] = ax2qu_single(ax[i])
     return qu
 
@@ -517,55 +533,53 @@ def ax2qu(axes: np.ndarray, angles: np.ndarray) -> np.ndarray:
     Parameters
     ----------
     axes
-        (...,3) dimensional numpy array of (x, y, z) vectors.
+        N-dimensional array of (x, y, z) vectors with the final
+        dimension equal to 3.
     angles
-        numpy array of angles in radians.
+        Angles in radians.
 
     Returns
     -------
     qu
         2D array of n (a, b, c, d) as 64-bit floats.
-
     """
-    # convert to numpy arrays of shape (...,3) and (...,1)
     axes = np.atleast_2d(axes)
     angles = np.atleast_1d(angles)
+
     if axes.shape[-1] != 3:
-        raise ValueError("axes must be an array of shape (...,3)")
+        raise ValueError("Final dimension of axes array must be 3.")
     if angles.shape[-1] != 1 or angles.shape == (1,):
         angles = angles.reshape(angles.shape + (1,))
-    # get the shape of the data itself.
-    ax_shape = axes.shape[:-1]
-    ang_shape = angles.shape[:-1]
-    # case of n-dimensional axis and single angle
-    if ang_shape == (1,):
-        angles = np.ones(ax_shape + (1,)) * angles
-    # case of single axis and n-dimensional angle
-    elif ax_shape == (1,):
-        axes = np.ones(ang_shape + (3,)) * axes
-    elif ax_shape != ang_shape:
-        raise ValueError(
-            """
-        The dimensions of axes and angles are {} and {}, respectively.
-        Either the dimensions must match, or one must be a singular value.
-        """.format(
-                axes.shape, angles.shape
-            )
-        )
-    ax = np.concatenate([axes.data, angles], axis=-1)
 
-    # convert the 'ax' array to the 2D array expected by ax2qu_2d
-    n_ax = np.prod(ax.shape[:-1])
-    ax2d = ax.astype(np.float64).reshape(n_ax, 4)
-    # reshape the resulting quaternion to the original shape.
-    qu = ax2qu_2d(ax2d).reshape(ax.shape)
+    axes_shape = axes.shape[:-1]
+    angles_shape = angles.shape[:-1]
+
+    if angles_shape == (1,):
+        # N-dimensional axis and single angle
+        angles = np.ones(axes_shape + (1,)) * angles
+    elif axes_shape == (1,):
+        # Single axis and n-dimensional angle
+        axes = np.ones(angles_shape + (3,)) * axes
+    elif axes_shape != angles_shape:
+        raise ValueError(
+            f"The dimensions of axes {axes_shape} and angles {angles_shape} are "
+            "incompatible. The dimensions must match or one must be a singular value."
+        )
+
+    axes_angles = np.concatenate([axes.data, angles], axis=-1)
+    axes_angles_2d = axes_angles.reshape(-1, 4)
+    axes_angles_2d = axes_angles_2d.astype(np.float64)
+
+    qu = ax2qu_2d(axes_angles_2d)
+    qu = qu.reshape(axes_angles.shape)
+
     return qu
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
 def qu2ax_single(qu: np.ndarray) -> np.ndarray:
-    """Conversion from a single un-normalized quaternion to an
-    axos-angle pair :cite:`rowenhorst2015consistent`.
+    """Convert a single (un)normalized quaternion to a normalized
+    axis-angle pair :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -579,27 +593,33 @@ def qu2ax_single(qu: np.ndarray) -> np.ndarray:
 
     Notes
     -----
-    Uses Eqs. A.16 :cite:`rowenhorst2015consistent`.
+    Uses Eq. A.16 in :cite:`rowenhorst2015consistent`.
+
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
     omega = 2 * np.arccos(qu[0])
+
     if omega < FLOAT_EPS:
-        return np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float64)
+        return np.array([0, 0, 1, 0], dtype=np.float64)
+
     if np.abs(qu[0]) < FLOAT_EPS:
         return np.array([qu[1], qu[2], qu[3], np.pi], dtype=np.float64)
-    s = -1
-    if qu[0] > 0:
-        s = 1
-    s = s / np.sqrt(np.sum(qu[1:4] ** 2))
-    ax = np.array([s * qu[1], s * qu[2], s * qu[3], omega], dtype=np.float64)
+
+    s = np.sqrt(np.sum(np.square(qu[1:])))
+    if qu[0] <= 0:
+        s = -s
+
+    ax = np.array([qu[1], qu[2], qu[3], omega], dtype=np.float64)
+    ax[:3] = ax[:3] / s
+
     return ax
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def qu2ax_2d(qu: np.ndarray) -> np.ndarray:
-    """Conversion from multiple un-normalized quaternions to axis-angle
-    pairs :cite:`rowenhorst2015consistent`.
+    """Convert multiple (un)normalized quaternions to normalized
+    axis-angle pairs :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -616,46 +636,52 @@ def qu2ax_2d(qu: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_vectors = qu.shape[0]
-    ax = np.zeros((n_vectors, 4), dtype=np.float64)
-    for i in nb.prange(n_vectors):
+    n = qu.shape[0]
+    ax = np.zeros((n, 4), dtype=np.float64)
+    for i in nb.prange(n):
         ax[i] = qu2ax_single(qu[i])
     return ax
 
 
-def qu2ax(qu: np.ndarray) -> np.ndarray:
+def qu2ax(qu: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     """N-dimensional wrapper for qu2ax_2d, see the docstring of that
     function for further details.
 
     Parameters
     ----------
     qu
-        2D array of n (a, b, c, d) as 64-bit floats.
+        Quaternion(s) (a, b, c, d) with the final array dimension equal
+        to 4.
 
     Returns
     -------
     axes
-        (...,3) dimensional numpy array of (x, y, z) vectors.
+        Rotation axes of the same shape as the input array but with the
+        final array dimension equal to 3.
     angles
-        (...,1) dimensional numpy array of angles in radians.
-
+        Rotation angles in radians of the same shape as the input array
+        but with the final array dimension equal to 1.
     """
-    # convert qu to a numpy array of shape (...,4)
     qu_nd = np.atleast_2d(qu)
-    # assert the shape makes sense for a quaternion
+
     if qu_nd.shape[-1] != 4:
-        raise ValueError("input must be an array of shape (...,4)")
-    # convert the 'qu_nd' array to the 2D array expected by qu2ax_2d
-    n_qu = np.prod(qu.shape[:-1])
-    qu2d = qu.astype(np.float64).reshape(n_qu, 4)
-    # reshape the resulting axis/angle to the original shape.
-    axang = qu2ax_2d(qu2d).reshape(qu_nd.shape)
-    return (axang[..., :3], axang[..., 3].reshape(axang.shape[:-1] + (1,)))
+        raise ValueError("Final dimension of quaternion array must be 4.")
+
+    qu2d = qu.reshape(-1, 4)
+    qu2d = qu2d.astype(np.float64)
+
+    ax = qu2ax_2d(qu2d)
+    ax = ax.reshape(qu.shape)
+
+    axes = ax[..., :3]
+    angles = ax[..., 3].reshape(ax.shape[:-1] + (1,))
+
+    return axes, angles
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
 def ho2ro_single(ho: np.ndarray) -> np.ndarray:
-    """Conversion from a single set of homochoric coordinates to an
+    """Convert a single set of homochoric coordinates to an
     un-normalized Rodrigues vector :cite:`rowenhorst2015consistent`.
 
     Parameters
@@ -678,7 +704,7 @@ def ho2ro_single(ho: np.ndarray) -> np.ndarray:
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def ho2ro_2d(ho: np.ndarray) -> np.ndarray:
-    """Conversion from multiple homochoric coordinates to un-normalized
+    """Convert multiple homochoric coordinates to un-normalized
     Rodrigues vectors :cite:`rowenhorst2015consistent`.
 
     Parameters
@@ -696,9 +722,9 @@ def ho2ro_2d(ho: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_vectors = ho.shape[0]
-    ro = np.zeros((n_vectors, 4), dtype=np.float64)
-    for i in nb.prange(n_vectors):
+    n = ho.shape[0]
+    ro = np.zeros((n, 4), dtype=np.float64)
+    for i in nb.prange(n):
         ro[i] = ho2ro_single(ho[i])
     return ro
 
@@ -707,15 +733,18 @@ def ho2ro(ho: np.ndarray) -> np.ndarray:
     """N-dimensional wrapper for ho2ro_2d, see the docstring of that
     function.
     """
-    n_ho = np.prod(ho.shape[:-1])
-    ho2d = ho.astype(np.float64).reshape(n_ho, 3)
-    ro = ho2ro_2d(ho2d).reshape(ho.shape[:-1] + (4,))
+    ho2d = ho.astype(np.float64)
+    ho2d = ho2d.reshape(-1, 3)
+
+    ro = ho2ro_2d(ho2d)
+    ro = ro.reshape(ho.shape[:-1] + (4,))
+
     return ro
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
 def cu2ro_single(cu: np.ndarray) -> np.ndarray:
-    """Conversion from a single set of cubochoric coordinates to an
+    """Convert a single set of cubochoric coordinates to an
     un-normalized Rodrigues vector :cite:`rowenhorst2015consistent`.
 
     Parameters
@@ -741,7 +770,7 @@ def cu2ro_single(cu: np.ndarray) -> np.ndarray:
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def cu2ro_2d(cu: np.ndarray) -> np.ndarray:
-    """Conversion from multiple cubochoric coordinates to un-normalized
+    """Convert multiple cubochoric coordinates to un-normalized
     Rodrigues vectors :cite:`rowenhorst2015consistent`.
 
     Parameters
@@ -759,9 +788,9 @@ def cu2ro_2d(cu: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_vectors = cu.shape[0]
-    ro = np.zeros((n_vectors, 4), dtype=np.float64)
-    for i in nb.prange(n_vectors):
+    n = cu.shape[0]
+    ro = np.zeros((n, 4), dtype=np.float64)
+    for i in nb.prange(n):
         ro[i] = cu2ro_single(cu[i])
     return ro
 
@@ -770,22 +799,25 @@ def cu2ro(cu: np.ndarray) -> np.ndarray:
     """N-dimensional wrapper for cu2ro_2d, see the docstring of that
     function.
     """
-    n_cu = np.prod(cu.shape[:-1])
-    cu2d = cu.astype(np.float64).reshape(n_cu, 3)
-    ro = cu2ro_2d(cu2d).reshape(cu.shape[:-1] + (4,))
+    cu2d = cu.astype(np.float64)
+    cu2d = cu2d.reshape(-1, 3)
+
+    ro = cu2ro_2d(cu2d)
+    ro = ro.reshape(cu.shape[:-1] + (4,))
+
     return ro
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
 def eu2qu_single(eu: np.ndarray) -> np.ndarray:
     """Convert three Euler angles (alpha, beta, gamma) to a unit
-    quaternion.
+    quaternion :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
     eu
         1D array of (alpha, beta, gamma) Euler angles given in radians
-        in the Bunge convention (ie, passive Z-X-Z) as 64-bit floats.
+        in the Bunge convention (i.e., passive Z-X-Z) as 64-bit floats.
 
     Returns
     -------
@@ -794,7 +826,7 @@ def eu2qu_single(eu: np.ndarray) -> np.ndarray:
 
     Notes
     -----
-    Uses Eqs. A.5 & A.6 :cite:`rowenhorst2015consistent`.
+    Uses Eqs. A.5 & A.6 in :cite:`rowenhorst2015consistent`.
 
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
@@ -818,8 +850,8 @@ def eu2qu_single(eu: np.ndarray) -> np.ndarray:
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def eu2qu_2d(eu: np.ndarray) -> np.ndarray:
-    """Conversion from multiple Euler angles (alpha, beta, gamma) to unit
-    quaternions
+    """Convert multiple Euler angles (alpha, beta, gamma) to unit
+    quaternions.
 
     Parameters
     ----------
@@ -836,9 +868,9 @@ def eu2qu_2d(eu: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_vectors = eu.shape[0]
-    qu = np.zeros((n_vectors, 4), dtype=np.float64)
-    for i in nb.prange(n_vectors):
+    n = eu.shape[0]
+    qu = np.zeros((n, 4), dtype=np.float64)
+    for i in nb.prange(n):
         qu[i] = eu2qu_single(eu[i])
     return qu
 
@@ -847,15 +879,19 @@ def eu2qu(eu: np.ndarray) -> np.ndarray:
     """N-dimensional wrapper for eu2qu_2d, see the docstring of that
     function.
     """
-    n_eu = np.prod(eu.shape[:-1])
-    eu2d = eu.astype(np.float64).reshape(n_eu, 3)
-    qu = eu2qu_2d(eu2d).reshape(eu.shape[:-1] + (4,))
+    eu2d = eu.astype(np.float64)
+    eu2d = eu2d.reshape(-1, 3)
+
+    qu = eu2qu_2d(eu2d)
+    qu = qu.reshape(eu.shape[:-1] + (4,))
+
     return qu
 
 
 @nb.jit("float64[:](float64[:, :])", cache=True, nogil=True, nopython=True)
 def om2qu_single(om: np.ndarray) -> np.ndarray:
-    """Convert a single (3,3) rotation matrix into a unit quaternion
+    """Convert a single (3, 3) rotation matrix to a unit quaternion
+    :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -869,54 +905,54 @@ def om2qu_single(om: np.ndarray) -> np.ndarray:
 
     Notes
     -----
-    Uses Eqs. A.11 :cite:`rowenhorst2015consistent`.
+    Uses Eq. A.11 in :cite:`rowenhorst2015consistent`.
 
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-
-    q0_almost = 1 + om[0, 0] + om[1, 1] + om[2, 2]
-    q1_almost = 1 + om[0, 0] - om[1, 1] - om[2, 2]
-    q2_almost = 1 - om[0, 0] + om[1, 1] - om[2, 2]
-    q3_almost = 1 - om[0, 0] - om[1, 1] + om[2, 2]
+    a_almost = 1 + om[0, 0] + om[1, 1] + om[2, 2]
+    b_almost = 1 + om[0, 0] - om[1, 1] - om[2, 2]
+    c_almost = 1 - om[0, 0] + om[1, 1] - om[2, 2]
+    d_almost = 1 - om[0, 0] - om[1, 1] + om[2, 2]
 
     qu = np.zeros(4, dtype=np.float64)
-    eps = np.finfo(np.float64).eps
 
-    if q0_almost < eps:
+    if a_almost < FLOAT_EPS:
         qu[0] = 0
     else:
-        qu[0] = 0.5 * np.sqrt(q0_almost)
+        qu[0] = 0.5 * np.sqrt(a_almost)
 
-    if q1_almost < eps:
+    if b_almost < FLOAT_EPS:
         qu[1] = 0
     elif om[2, 1] < om[1, 2]:
-        qu[1] = -0.5 * np.sqrt(q1_almost)
+        qu[1] = -0.5 * np.sqrt(b_almost)
     else:
-        qu[1] = 0.5 * np.sqrt(q1_almost)
+        qu[1] = 0.5 * np.sqrt(b_almost)
 
-    if q2_almost < eps:
+    if c_almost < FLOAT_EPS:
         qu[2] = 0
     elif om[0, 2] < om[2, 0]:
-        qu[2] = -0.5 * np.sqrt(q2_almost)
+        qu[2] = -0.5 * np.sqrt(c_almost)
     else:
-        qu[2] = 0.5 * np.sqrt(q2_almost)
+        qu[2] = 0.5 * np.sqrt(c_almost)
 
-    if q3_almost < eps:
+    if d_almost < FLOAT_EPS:
         qu[3] = 0
     elif om[1, 0] < om[0, 1]:
-        qu[3] = -0.5 * np.sqrt(q3_almost)
+        qu[3] = -0.5 * np.sqrt(d_almost)
     else:
-        qu[3] = 0.5 * np.sqrt(q3_almost)
+        qu[3] = 0.5 * np.sqrt(d_almost)
 
     norm = np.sqrt(np.sum(np.square(qu)))
     qu = qu / norm
+
     return qu
 
 
 @nb.jit("float64[:, :](float64[:, :, :])", cache=True, nogil=True, nopython=True)
 def om2qu_3d(om: np.ndarray) -> np.ndarray:
-    """Conversion from multiple rotation matrices to unit quaternions
+    """Convert multiple rotation matrices to unit quaternions
+    :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -926,64 +962,65 @@ def om2qu_3d(om: np.ndarray) -> np.ndarray:
     Returns
     -------
     qu
-        2D array of n (q0, q1, q2, q3) quaternions as 64-bit floats.
+        2D array of n (a, b, c, d) quaternions as 64-bit floats.
 
     Notes
     -----
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_vectors = om.shape[0]
-    qu = np.zeros((n_vectors, 4), dtype=np.float64)
-    for i in nb.prange(n_vectors):
+    n = om.shape[0]
+    qu = np.zeros((n, 4), dtype=np.float64)
+    for i in nb.prange(n):
         qu[i] = om2qu_single(om[i])
     return qu
 
 
 def om2qu(om: np.ndarray) -> np.ndarray:
     """N-dimensional wrapper for om2qu_3d, see the docstring of that
-    function.
+    function for further details.
     """
-    if om.shape == (3, 3):
-        n_om = 1
-    else:
-        n_om = np.prod(om.shape[:-2])
-    om3d = om.astype(np.float64).reshape(n_om, 3, 3)
-    qu = om2qu_3d(om3d).reshape(om.shape[:-2] + (4,))
+    om3d = om.reshape((-1, 3, 3))
+    om3d = om3d.astype(np.float64)
+
+    qu = om2qu_3d(om3d)
+    qu = qu.reshape(om.shape[:-2] + (4,))
+
     return qu
 
 
 @nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
 def qu2eu_single(qu: np.ndarray) -> np.ndarray:
-    """Convert a unit quaternion to three Euler angles.
+    """Convert a unit quaternion to three Euler angles
+    :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
     qu
-        a unit quaternion.
+        Unit quaternion (a, b, c, d).
 
     Return
     ------
     eu
-        (alpha, beta, gamma) Euler angles given in radians
-        in the Bunge convention (ie, passive Z-X-Z).
+        Euler angles (alpha, beta, gamma) in radians in the Bunge
+        convention (i.e., passive Z-X-Z).
 
     Notes
     -----
-    Uses Eqs. A.14 :cite:`rowenhorst2015consistent`.
+    Uses Eq. A.14 in :cite:`rowenhorst2015consistent`.
 
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
     eu = np.zeros(3, dtype=np.float64)
 
-    # Following A.14, compute q_03, q_12, and chi, assuming P=1
-    q_03 = (qu[0] * qu[0]) + (qu[3] * qu[3])
-    q_12 = (qu[1] * qu[1]) + (qu[2] * qu[2])
-    chi = np.sqrt(q_03 * q_12)
-    # account for cases where chi is below rounding error
+    # Following Eq. A.14, compute q_ad, q_bc, and chi, assuming P=1
+    q_ad = (qu[0] * qu[0]) + (qu[3] * qu[3])
+    q_bc = (qu[1] * qu[1]) + (qu[2] * qu[2])
+    chi = np.sqrt(q_ad * q_bc)
+
     if chi < FLOAT_EPS:
-        if q_12 < FLOAT_EPS:
+        if q_bc < FLOAT_EPS:
             a = -2 * qu[0] * qu[3]
             b = qu[0] * qu[0] - qu[3] * qu[3]
         else:
@@ -992,31 +1029,29 @@ def qu2eu_single(qu: np.ndarray) -> np.ndarray:
             eu[1] = np.pi
         eu[0] = np.arctan2(a, b)
         return np.mod(eu, np.pi * 2)
-    # account for the generic case
-    eu_0a = ((qu[1] * qu[3]) - (qu[0] * qu[2])) / chi
-    eu_0b = (-(qu[0] * qu[1]) - (qu[2] * qu[3])) / chi
-    eu_2a = ((qu[0] * qu[2]) + (qu[1] * qu[3])) / chi
-    eu_2b = ((qu[2] * qu[3]) - (qu[0] * qu[1])) / chi
+
+    eu_0a = (qu[1] * qu[3] - qu[0] * qu[2]) / chi
+    eu_0b = (-qu[0] * qu[1] - qu[2] * qu[3]) / chi
+    eu_2a = (qu[0] * qu[2] + qu[1] * qu[3]) / chi
+    eu_2b = (qu[2] * qu[3] - qu[0] * qu[1]) / chi
 
     eu[0] = np.arctan2(eu_0a, eu_0b)
-    eu[1] = np.arctan2(2 * chi, q_03 - q_12)
+    eu[1] = np.arctan2(2 * chi, q_ad - q_bc)
     eu[2] = np.arctan2(eu_2a, eu_2b)
 
-    # account for rounding errors
     eu[np.abs(eu) < FLOAT_EPS] = 0
-    # convert negative angles to positives and return the result
+
     return np.mod(eu, np.pi * 2)
 
 
 @nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def qu2eu_2d(qu: np.ndarray) -> np.ndarray:
-    """Conversion from an n-by-4 array of unit quaternions to an n-by-3
-    array of Euler angles.
+    """Convert multiple unit quaternions to Euler angles.
 
     Parameters
     ----------
     qu
-        2D array of n (q0, q1, q2, q3) quaternions as 64-bit floats.
+        2D array of n (a, b, c, d) quaternions as 64-bit floats.
 
     Returns
     -------
@@ -1028,9 +1063,9 @@ def qu2eu_2d(qu: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_vectors = qu.shape[0]
-    eu = np.zeros((n_vectors, 3), dtype=np.float64)
-    for i in nb.prange(n_vectors):
+    n = qu.shape[0]
+    eu = np.zeros((n, 3), dtype=np.float64)
+    for i in nb.prange(n):
         eu[i] = qu2eu_single(qu[i])
     return eu
 
@@ -1039,16 +1074,19 @@ def qu2eu(qu: np.ndarray) -> np.ndarray:
     """N-dimensional wrapper for qu2eu_2d, see the docstring of that
     function.
     """
-    n_qu = np.prod(qu.shape[:-1])
-    qu2d = qu.astype(np.float64).reshape(n_qu, 4)
-    eu = qu2eu_2d(qu2d).reshape(qu.shape[:-1] + (3,))
+    qu2d = qu.reshape(-1, 4)
+    qu2d = qu2d.astype(np.float64)
+
+    eu = qu2eu_2d(qu2d)
+    eu = eu.reshape(qu.shape[:-1] + (3,))
+
     return eu
 
 
 @nb.jit("float64[:, :](float64[:])", cache=True, nogil=True, nopython=True)
 def qu2om_single(qu: np.ndarray) -> np.ndarray:
-    """Convert a single unit quaternion into an orthogonal rotation
-    matrix.
+    """Convert a unit quaternion to an orthogonal rotation matrix
+     :cite:`rowenhorst2015consistent`.
 
     Parameters
     ----------
@@ -1062,26 +1100,25 @@ def qu2om_single(qu: np.ndarray) -> np.ndarray:
 
     Notes
     -----
-    Uses Eqs. A.15 :cite:`rowenhorst2015consistent`.
+    Uses Eq. A.15 :cite:`rowenhorst2015consistent`.
 
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-
     om = np.zeros((3, 3), dtype=np.float64)
-    # Following A.15, calculate q_mean (qq below)
+
     bb = qu[1] ** 2
     cc = qu[2] ** 2
     dd = qu[3] ** 2
-    qq = qu[0] ** 2 - (bb + cc + dd)
-    # calculate all the other values used in A.15
+    qq = qu[0] ** 2 - (bb + cc + dd)  # q_mean in Eq. A.15
+
     bc = qu[1] * qu[2]
     ad = qu[0] * qu[3]
     bd = qu[1] * qu[3]
     ac = qu[0] * qu[2]
     cd = qu[2] * qu[3]
     ab = qu[0] * qu[1]
-    # calculate the matrix itself
+
     om[0, 0] = qq + 2 * bb
     om[0, 1] = 2 * (bc - ad)
     om[0, 2] = 2 * (bd + ac)
@@ -1097,7 +1134,7 @@ def qu2om_single(qu: np.ndarray) -> np.ndarray:
 
 @nb.jit("float64[:, :, :](float64[:, :])", cache=True, nogil=True, nopython=True)
 def qu2om_2d(qu: np.ndarray) -> np.ndarray:
-    """Conversion from multiple unit quaternions to orthogonal rotation
+    """Convert multiple unit quaternions to orthogonal rotation
     matrices.
 
     Parameters
@@ -1115,9 +1152,9 @@ def qu2om_2d(qu: np.ndarray) -> np.ndarray:
     This function is optimized with Numba, so care must be taken with
     array shapes and data types.
     """
-    n_vectors = qu.shape[0]
-    om = np.zeros((n_vectors, 3, 3), dtype=np.float64)
-    for i in nb.prange(n_vectors):
+    n = qu.shape[0]
+    om = np.zeros((n, 3, 3), dtype=np.float64)
+    for i in nb.prange(n):
         om[i, :, :] = qu2om_single(qu[i])
     return om
 
@@ -1126,7 +1163,101 @@ def qu2om(qu: np.ndarray) -> np.ndarray:
     """N-dimensional wrapper for om2qu_3d, see the docstring of that
     function.
     """
-    n_qu = np.prod(qu.shape[:-1])
-    qu2d = qu.astype(np.float64).reshape(n_qu, 4)
-    om = qu2om_2d(qu2d).reshape(qu.shape[:-1] + (3, 3))
+    qu2d = qu.reshape(-1, 4)
+    qu2d = qu2d.astype(np.float64)
+
+    om = qu2om_2d(qu2d)
+    om = om.reshape(qu.shape[:-1] + (3, 3))
+
     return om
+
+
+@nb.jit("float64[:](float64[:])", cache=True, nogil=True, nopython=True)
+def qu2ho_single(qu: np.ndarray) -> np.ndarray:
+    """Convert a single (un)normalized quaternion to a normalized
+    homochoric vector :cite:`rowenhorst2015consistent`.
+
+    Parameters
+    ----------
+    qu
+        1D array of (a, b, c, d) as 64-bit floats.
+
+    Returns
+    -------
+    ho
+        1D array of (x, y, z) as 64-bit floats.
+
+    Notes
+    -----
+    Uses Eq. A.25 in :cite:`rowenhorst2015consistent`.
+
+    This function is optimized with Numba, so care must be taken with
+    array shapes and data types.
+    """
+    omega = 2 * np.arccos(qu[0])
+
+    if omega < FLOAT_EPS:
+        return np.zeros(3, dtype=np.float64)
+
+    s = np.sqrt(np.sum(np.square(qu[1:])))
+    n = qu[1:] / s
+    f = 3 * (omega - np.sin(omega)) / 4
+    ho = n * f ** (1 / 3)
+
+    return ho
+
+
+@nb.jit("float64[:, :](float64[:, :])", cache=True, nogil=True, nopython=True)
+def qu2ho_2d(qu: np.ndarray) -> np.ndarray:
+    """Convert multiple (un)normalized quaternions to normalized
+    homochoric vectors :cite:`rowenhorst2015consistent`.
+
+    Parameters
+    ----------
+    qu
+        2D array of n (a, b, c, d) as 64-bit floats.
+
+    Returns
+    -------
+    ho
+        2D array of n (x, y, z) as 64-bit floats.
+
+    Notes
+    -----
+    This function is optimized with Numba, so care must be taken with
+    array shapes and data types.
+    """
+    n = qu.shape[0]
+    ho = np.zeros((n, 3), dtype=np.float64)
+    for i in nb.prange(n):
+        ho[i] = qu2ho_single(qu[i])
+    return ho
+
+
+def qu2ho(qu: np.ndarray) -> np.ndarray:
+    """N-dimensional wrapper for qu2ho_2d, see the docstring of that
+    function for further details.
+
+    Parameters
+    ----------
+    qu
+        Quaternion(s) (a, b, c, d) with the final array dimension equal
+        to 4.
+
+    Returns
+    -------
+    ho
+        Homochoric vectors (x, y, z).
+    """
+    qu_nd = np.atleast_2d(qu)
+
+    if qu_nd.shape[-1] != 4:
+        raise ValueError("Final dimension of quaternion array must be 4.")
+
+    qu2d = qu.reshape(-1, 4)
+    qu2d = qu2d.astype(np.float64)
+
+    ho = qu2ho_2d(qu2d)
+    ho = ho.reshape(qu.shape[:-1] + (3,))
+
+    return ho

--- a/orix/quaternion/misorientation.py
+++ b/orix/quaternion/misorientation.py
@@ -24,7 +24,6 @@ import warnings
 
 import dask.array as da
 from dask.diagnostics import ProgressBar
-from diffpy.structure import Structure
 from matplotlib.gridspec import SubplotSpec
 import matplotlib.pyplot as plt
 import numpy as np
@@ -34,7 +33,7 @@ from tqdm import tqdm
 from orix.quaternion.orientation_region import OrientationRegion
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C1, Symmetry, _get_unique_symmetry_elements
-from orix.vector import AxAngle, Miller, NeoEuler, Vector3d
+from orix.vector import Miller
 
 
 class Misorientation(Rotation):

--- a/orix/quaternion/orientation.py
+++ b/orix/quaternion/orientation.py
@@ -18,8 +18,7 @@
 
 from __future__ import annotations
 
-from itertools import product as iproduct
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 import warnings
 
 import dask.array as da
@@ -29,14 +28,12 @@ from matplotlib.gridspec import SubplotSpec
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.spatial.transform import Rotation as SciPyRotation
-from tqdm import tqdm
 
-from orix._util import deprecated, deprecated_argument
+from orix._util import deprecated
 from orix.quaternion.misorientation import Misorientation
-from orix.quaternion.orientation_region import OrientationRegion
 from orix.quaternion.rotation import Rotation
 from orix.quaternion.symmetry import C1, Symmetry, _get_unique_symmetry_elements
-from orix.vector import AxAngle, Miller, NeoEuler, Vector3d
+from orix.vector import Miller, NeoEuler, Vector3d
 
 
 class Orientation(Misorientation):
@@ -114,7 +111,8 @@ class Orientation(Misorientation):
         degrees: bool = False,
         **kwargs,
     ) -> Orientation:
-        """Initialize from an array of Euler angles.
+        """Create orientations from sets of Euler angles
+        :cite:`rowenhorst2015consistent`.
 
         Parameters
         ----------
@@ -134,13 +132,13 @@ class Orientation(Misorientation):
 
         Returns
         -------
-        ori
+        o
             Orientations.
         """
-        ori = super().from_euler(euler, direction=direction, degrees=degrees, **kwargs)
+        o = super().from_euler(euler, direction=direction, degrees=degrees, **kwargs)
         if symmetry:
-            ori.symmetry = symmetry
-        return ori
+            o.symmetry = symmetry
+        return o
 
     @classmethod
     def from_align_vectors(
@@ -156,7 +154,7 @@ class Orientation(Misorientation):
         Tuple[Orientation, np.ndarray],
         Tuple[Orientation, float, np.ndarray],
     ]:
-        """Return an estimated orientation to optimally align vectors in
+        """Create an estimated orientation to optimally align vectors in
         the crystal and sample reference frames.
 
         This method wraps
@@ -202,10 +200,10 @@ class Orientation(Misorientation):
         >>> from orix.quaternion import Orientation
         >>> from orix.vector import Vector3d, Miller
         >>> from orix.crystal_map import Phase
-        >>> uvw = Miller(uvw=[[0, 1, 0], [1, 0, 0]], phase=Phase(point_group="m-3m"))
+        >>> t = Miller(uvw=[[0, 1, 0], [1, 0, 0]], phase=Phase(point_group="m-3m"))
         >>> v_sample = Vector3d([[0, -1, 0], [0, 0, 1]])
-        >>> ori = Orientation.from_align_vectors(uvw, v_sample)
-        >>> ori * v_sample
+        >>> o = Orientation.from_align_vectors(t, v_sample)
+        >>> o * v_sample
         Vector3d (2,)
         [[0. 1. 0.]
          [1. 0. 0.]]
@@ -236,7 +234,7 @@ class Orientation(Misorientation):
     def from_matrix(
         cls, matrix: np.ndarray, symmetry: Optional[Symmetry] = None
     ) -> Orientation:
-        """Return orientation(s) from orientation matrices
+        """Create orientations from orientation matrices
         :cite:`rowenhorst2015consistent`.
 
         Parameters
@@ -249,22 +247,22 @@ class Orientation(Misorientation):
 
         Returns
         -------
-        ori
+        o
             Orientations.
         """
-        ori = super().from_matrix(matrix)
+        o = super().from_matrix(matrix)
         if symmetry:
-            ori.symmetry = symmetry
-        return ori
+            o.symmetry = symmetry
+        return o
 
     # TODO: Remove before 0.13.0
     @classmethod
-    @deprecated(since="0.12", removal="0.13")
+    @deprecated(since="0.12", removal="0.13", alternative="from_axes_angles")
     def from_neo_euler(
         cls, neo_euler: NeoEuler, symmetry: Optional[Symmetry] = None
     ) -> Orientation:
-        """Return orientation(s) from a neo-euler (vector)
-        representation.
+        """Create orientations from a neo-euler (vector) representation.
+
         Parameters
         ----------
         neo_euler
@@ -272,15 +270,16 @@ class Orientation(Misorientation):
         symmetry
             Symmetry of orientation(s). If not given (default), no
             symmetry is set.
+
         Returns
         -------
-        ori
+        o
             Orientations.
         """
-        ori = super().from_neo_euler(neo_euler)
+        o = super().from_neo_euler(neo_euler)
         if symmetry:
-            ori.symmetry = symmetry
-        return ori
+            o.symmetry = symmetry
+        return o
 
     @classmethod
     def from_axes_angles(
@@ -290,7 +289,8 @@ class Orientation(Misorientation):
         symmetry: Optional[Symmetry] = None,
         degrees: bool = False,
     ) -> Orientation:
-        """Initialize from axis-angle pair(s).
+        """Create orientations from axis-angle pairs
+        :cite:`rowenhorst2015consistent`.
 
         Parameters
         ----------
@@ -308,21 +308,21 @@ class Orientation(Misorientation):
 
         Returns
         -------
-        ori
+        o
             Orientation(s).
 
         Examples
         --------
         >>> from orix.quaternion import Orientation, symmetry
-        >>> ori = Orientation.from_axes_angles((0, 0, -1), 90, symmetry.Oh, degrees=True)
-        >>> ori
+        >>> o = Orientation.from_axes_angles((0, 0, -1), 90, symmetry.Oh, degrees=True)
+        >>> o
         Orientation (1,) m-3m
         [[ 0.7071  0.      0.     -0.7071]]
         """
-        ori = super().from_axes_angles(axes, angles, degrees)
+        o = super().from_axes_angles(axes, angles, degrees)
         if symmetry:
-            ori.symmetry = symmetry
-        return ori
+            o.symmetry = symmetry
+        return o
 
     @classmethod
     def from_scipy_rotation(
@@ -356,11 +356,11 @@ class Orientation(Misorientation):
         >>> from orix.vector import Vector3d
         >>> from scipy.spatial.transform import Rotation as SciPyRotation
         >>> r_scipy = SciPyRotation.from_euler("ZXZ", [90, 0, 0], degrees=True)
-        >>> ori = Orientation.from_scipy_rotation(r_scipy, symmetry.Oh)
+        >>> o = Orientation.from_scipy_rotation(r_scipy, symmetry.Oh)
         >>> v = [1, 1, 0]
         >>> r_scipy.apply(v)
         array([-1.,  1.,  0.])
-        >>> ori * Vector3d(v)
+        >>> o * Vector3d(v)
         Vector3d (1,)
         [[ 1. -1.  0.]]
         """
@@ -454,20 +454,20 @@ class Orientation(Misorientation):
         Examples
         --------
         >>> from orix.quaternion import Orientation, symmetry
-        >>> ori1 = Orientation.random((5, 3))
-        >>> ori2 = Orientation.random((6, 2))
-        >>> dist1 = ori1.angle_with_outer(ori2)
+        >>> o1 = Orientation.random((5, 3))
+        >>> o2 = Orientation.random((6, 2))
+        >>> dist1 = o1.angle_with_outer(o2)
         >>> dist1.shape
         (5, 3, 6, 2)
-        >>> ori1.symmetry = symmetry.Oh
-        >>> ori2.symmetry = symmetry.Oh
-        >>> dist_sym = ori1.angle_with_outer(ori2)
+        >>> o1.symmetry = symmetry.Oh
+        >>> o2.symmetry = symmetry.Oh
+        >>> dist_sym = o1.angle_with_outer(o2)
         >>> np.allclose(dist1.data, dist_sym.data)
         False
         """
-        ori = self.unit
+        o = self.unit
         if lazy:
-            dot_products = ori._dot_outer_dask(other, chunk_size=chunk_size)
+            dot_products = o._dot_outer_dask(other, chunk_size=chunk_size)
             # Round because some dot products are slightly above 1
             n_decimals = np.finfo(dot_products.dtype).precision
             dot_products = da.round(dot_products, n_decimals)
@@ -483,7 +483,7 @@ class Orientation(Misorientation):
             else:
                 da.store(sources=angles_dask, targets=angles)
         else:
-            dot_products = ori.dot_outer(other)
+            dot_products = o.dot_outer(other)
             angles = np.arccos(2 * dot_products**2 - 1)
             angles = np.nan_to_num(angles)
 
@@ -693,9 +693,9 @@ class Orientation(Misorientation):
 
         # Symmetrize every orientation by operations of the proper
         # subgroup different from rotation about the c-axis
-        ori = pg._special_rotation.outer(self)
+        o = pg._special_rotation.outer(self)
 
-        alpha, beta, gamma = ori.to_euler().T
+        alpha, beta, gamma = o.to_euler().T
         gamma = np.mod(gamma, 2 * np.pi / pg._primary_axis_order)
 
         # Find the first triplet among the symmetrically equivalent ones

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -259,7 +259,7 @@ class Quaternion(Object3d):
 
         See Also
         --------
-        from_rodrigues
+        from_rodrigues, from_homochoric
         """
         if np.size(axes) == 0:
             return cls.empty()
@@ -288,13 +288,17 @@ class Quaternion(Object3d):
         ho
             Homochoric vectors parallel to the axes of rotation with
             lengths equal to
-            :math:`0.75\cdot(\theta - \sin(\theta))^{1/3}`, where
-            :math:`\theta` is the angle of rotation.
+            :math:`\left[\frac{3}{4}\cdot(\theta - \sin(\theta))\right]^{1/3}`,
+            where :math:`\theta` is the angle of rotation.
 
         Returns
         -------
         q
             Unit quaternions.
+
+        See Also
+        --------
+        from_axes_angles, from_rodrigues
         """
         if np.size(ho) == 0:
             return cls.empty()
@@ -323,24 +327,31 @@ class Quaternion(Object3d):
         ro: Union[np.ndarray, Vector3d, tuple, list],
         angles: Union[np.ndarray, tuple, list, float, None] = None,
     ) -> Quaternion:
-        r"""Create unit quaternions from Rodrigues vectors or
-        Rodrigues-Frank vectors :cite:`rowenhorst2015consistent`.
+        r"""Create unit quaternions from Rodrigues vectors
+        :math:`\hat{\mathbf{n}}` or Rodrigues-Frank vectors
+        :math:`\mathbf{\rho}` :cite:`rowenhorst2015consistent`.
 
         Parameters
         ----------
         ro
             Rodrigues vectors :math:`\hat{\mathbf{n}}` of three
             components. These are the components of the Rodrigues-Frank
-            vectors if the angles ``omega`` are passed.
+            vectors :math:`\mathbf{\rho}` if the angles :math:`\omega`
+            are passed.
         angles
-            Angles :math:`\omega` of the Rodrigues-Frank vectors ``ro``,
-            one per vector. If these are not passed, ``ro`` are
-            the Rodrigues vectors.
+            Angles :math:`\omega` of the Rodrigues-Frank vectors
+            :math:`\mathbf{\rho}`, one per vector. If these are not
+            passed, ``ro`` are the Rodrigues vectors
+            :math:`\hat{\mathbf{n}}`.
 
         Returns
         -------
         q
             Unit quaternions.
+
+        See Also
+        --------
+        from_axes_angles, from_homochoric
 
         Notes
         -------
@@ -350,7 +361,7 @@ class Quaternion(Object3d):
 
             \mathbf{\rho} = \hat{\mathbf{n}}\tan\frac{\omega}{2}.
 
-        If the vector length is :math:`\rho = \|\mathbf{\rho}\|, the
+        If the vector length is :math:`\rho = |\mathbf{\rho}|`, the
         angle is given by
 
         .. math::
@@ -817,6 +828,10 @@ class Quaternion(Object3d):
             Axis-angle vectors with magnitude :math:`\theta` equal to
             the angle of rotation.
 
+        See Also
+        --------
+        to_homochoric, to_rodrigues
+
         Examples
         --------
         A 3-fold rotation around the [111] axis
@@ -853,6 +868,10 @@ class Quaternion(Object3d):
             rotation if ``frank=False`` or an array of four-component
             vectors if ``frank=True``.
 
+        See Also
+        --------
+        to_axes_angles, to_homochoric
+
         Examples
         --------
         A 3-fold rotation around the [111] axis
@@ -871,7 +890,7 @@ class Quaternion(Object3d):
         >>> np.linalg.norm(ro2[:, :3])
         1.0
 
-        A 45:math:`^{\circ}` rotation around the [111] axis
+        A 45:math:`\degree` rotation around the [111] axis
 
         >>> q2 = Quaternion.from_axes_angles([1, 1, 1], 45, degrees=True)
         >>> ro3 = q2.to_rodrigues()
@@ -908,8 +927,12 @@ class Quaternion(Object3d):
         ho
             Homochoric vectors parallel to the axes of rotation with
             lengths equal to
-            :math:`0.75\cdot(\theta - \sin(\theta))^{1/3}`, where
-            :math:`\theta` is the angle of rotation.
+            :math:`\left[\frac{3}{4}\cdot(\theta - \sin(\theta))\right]^{1/3}`,
+            where :math:`\theta` is the angle of rotation.
+
+        See Also
+        --------
+        to_axes_angles, from_rodrigues
 
         Examples
         --------

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -827,8 +827,8 @@ class Quaternion(Object3d):
         >>> ax
         AxAngle (1,)
         [[1.2092 1.2092 1.2092]]
-        >>> ax.angle
-        array([[120.]])
+        >>> np.rad2deg(ax.angle)
+        array([120.])
         """
         axes, angles = _conversions.qu2ax(self.unit.data)
         ax = AxAngle(axes * angles)
@@ -864,8 +864,9 @@ class Quaternion(Object3d):
         Rodrigues (1,)
         [[1. 1. 1.]]
         >>> ro1.norm
-        1.7320508075688776
+        array([1.73205081])
         >>> ro2 = q.to_rodrigues(frank=True)
+        >>> ro2
         array([[0.57735027, 0.57735027, 0.57735027, 1.73205081]])
         >>> np.linalg.norm(ro2[:, :3])
         1.0

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -30,7 +30,7 @@ from scipy.spatial.transform import Rotation as SciPyRotation
 from orix._util import deprecated, deprecated_argument
 from orix.base import Object3d
 from orix.quaternion import _conversions
-from orix.vector import AxAngle, Miller, Vector3d
+from orix.vector import AxAngle, Homochoric, Miller, Rodrigues, Vector3d
 
 # Used to round values below 1e-16 to zero
 _FLOAT_EPS = np.finfo(float).eps
@@ -70,7 +70,7 @@ class Quaternion(Object3d):
        v'_z = z(a^2 - b^2 - c^2 + d^2) + 2(y(a \cdot b + c \cdot d) + x(b \cdot d - a \cdot c))
     """
 
-    # -------------------------- Properties ------------------------- #
+    # --------------------------- Properties ------------------------- #
 
     dim = 4
 
@@ -140,7 +140,7 @@ class Quaternion(Object3d):
 
     @property
     def axis(self) -> Vector3d:
-        """Return the axes of rotation."""
+        """Return the axis of rotation."""
         axis = Vector3d(np.stack((self.b, self.c, self.d), axis=-1))
         a_is_zero = self.a < -1e-6
         axis[a_is_zero] = -axis[a_is_zero]
@@ -151,17 +151,17 @@ class Quaternion(Object3d):
 
     @property
     def angle(self) -> np.ndarray:
-        """Return the angles of rotation."""
+        """Return the angle of rotation."""
         return 2 * np.nan_to_num(np.arccos(np.abs(self.a)))
 
     @property
     def antipodal(self) -> Quaternion:
-        """Return the quaternions and the antipodal ones."""
+        """Return the quaternion and its antipodal."""
         return self.__class__(np.stack([self.data, -self.data]))
 
     @property
     def conj(self) -> Quaternion:
-        r"""Return the conjugate of this quaternion
+        r"""Return the conjugate of the quaternion
         :math:`q^* = a - bi - cj - dk`.
         """
         q = quaternion.from_float_array(self.data).conj()
@@ -196,11 +196,11 @@ class Quaternion(Object3d):
     def __neg__(self) -> Quaternion:
         return self.__class__(-self.data)
 
-    # ------------------- "from_*" class methods -------------------- #
+    # -------------------- from_*() class methods -------------------- #
 
     # TODO: Remove before 0.13.0
     @classmethod
-    @deprecated(since="0.12", removal="0.13")
+    @deprecated(since="0.12", removal="0.13", alternative="from_axes_angles")
     def from_neo_euler(cls, neo_euler: "NeoEuler") -> Quaternion:
         """Create unit quaternion(s) from a neo-euler (vector)
         representation.
@@ -224,129 +224,14 @@ class Quaternion(Object3d):
         return q
 
     @classmethod
-    def from_rodrigues(
-        cls, rod: Union[np.ndarray, Vector3d, tuple, list]
-    ) -> Quaternion:
-        """Create unit quaternion(s) from Rodrigues vector(s) of length
-        three, ie:
-            :math:`\omega * (n_1, n_2, n_3)`
-        for creating quaternions from Rodrigues-Franck vector(s) of length
-        four, ie:
-            :math:`(n_1,n_2,n_3, \omega)`
-        users should instead use Quaternion.from_rodrigues_frank.
-        see Notes for details on the differences.
-
-        Parameters
-        ----------
-        rod
-            Rodrigues vector representations interpretable as Vector3D
-            objects
-        ignore_warnings = False
-            Silences warnings related to large errors or vector length
-
-        Returns
-        -------
-        quat
-            Unit quaternion(s).
-
-        Notes
-        -------
-        Olinde Rodrigues's 1840 vector description was popularized by
-        F. C. Frank due to it's useful rectilinear mapping of fundamental
-        zones, as is well-demonstrated in the following paper:
-            https://doi.org/10.1007/BF02649253
-        This is the version expected as input in this function.
-
-        However, the length of these 3d vectors, and thus their accuracy,
-        scales with :math:`\tan(\theta/2)`.
-        Additionally two-fold rotations produce vectors of infinite length.
-        Thus, C.S. Frank and others introduced the Rodrigues-Frank Vector
-        of length 4, consisting of a unit vector followed by the scaling
-        factor. This is better suited for storing data or performing rotation
-        calculations, as covered in :cite:`rowenhorst2015consistent`.
-
-        Note, the definitions presented here for Rodrigues-Frank and
-        Rodrigues Vectors are not universally adopted. Additionally, some
-        codes prefer the (angle, axis) representation as opposed to Orix's
-        (axis, angle). Thus, caution should be exercised when importing data
-        from non-Orix sources.
-        """
-        # Check for Rodrigues-Frank vector
-        if type(rod) != Vector3d:
-            if np.atleast_2d(rod).shape[-1] == 4:
-                raise ValueError(
-                    "Requires an input array of shape (...,3). for "
-                    + "Rodrigues-Frank vectors of shape (...,4) use "
-                    + "Quaternion.from_rodrigues_frank() instead."
-                )
-        # At this point, it is fastest to convert to axis-angle format
-        # and pass the results to Quaternion.from_axis_angle
-        axes = Vector3d(rod)
-        norms = axes.norm
-        angles = np.arctan(norms) * 2
-        if axes.size * angles.size == 0:
-            return cls.empty()
-        # before passing, check for large angles and small errors
-        if np.rad2deg(np.max(angles)) > 179.999:
-            warnings.warn(
-                "Highest angle is greater than 179.999 degrees. Rodrigues"
-                + " Rodrigues vectors cannot paramtrize 2-fold rotations"
-                + "Consider an alternative class method."
-            )
-        if np.min(norms) < np.finfo(norms.dtype).resolution * 1000:
-            warnings.warn(
-                "Max. estimated error is greater than 0.1%. Rodrigues "
-                + "vectors have increasing associated errors for small "
-                + "angle rotations. Consider an alternative class method."
-            )
-
-        qu = cls.from_axes_angles(axes, angles)
-        return qu.unit
-
-    @classmethod
-    def from_rodrigues_frank(cls, rf: Union[np.ndarray, tuple, list]) -> Quaternion:
-        """Create unit quaternion(s) from Rodrigues-Frank vector(s) of
-        length four, ie:
-            :math:`(n_1,n_2,n_3, \omega)`
-        for creating quaternions from Rodrigues vector(s) of length
-        three, ie:
-            :math:`\omega * (n_1, n_2, n_3)`
-        users should instead use Quaternion.from_rodrigues.
-        see the Notes for that function for details on the differences.
-
-        Parameters
-        ----------
-        rf
-            Rodrigues-Frank representation interpretable as a numpy
-            array of shape (...,4)
-
-        Returns
-        -------
-        quat
-            Unit quaternion(s).
-        """
-        axes = np.atleast_2d(rf)
-        # Check for Rodrigues vector
-        if type(rf) == Vector3d or axes.shape[-1] == 3:
-            raise ValueError(
-                "Requires an input array of shape (...,4)."
-                + "for Rodrigues vectors of shape (...,3),"
-                + " use Quaternion.from_rodirigues instead"
-            )
-        if axes.size == 0:
-            return cls.empty()
-        ax = _conversions.ro2ax(axes)
-        qu = cls(_conversions.ax2qu(ax[..., :3], ax[..., 3]))
-        return qu.unit
-
-    @classmethod
     def from_axes_angles(
         cls,
         axes: Union[np.ndarray, Vector3d, tuple, list],
         angles: Union[np.ndarray, tuple, list, float],
         degrees: bool = False,
     ) -> Quaternion:
-        """Initialize from axis-angle pair(s).
+        """Create unit quaternions from axis-angle pairs
+        :cite:`rowenhorst2015consistent`.
 
         Parameters
         ----------
@@ -374,19 +259,157 @@ class Quaternion(Object3d):
 
         See Also
         --------
-        from_neo_euler
+        from_rodrigues
         """
-        # convert all the reasonable tuple, numpy, or list representations of
-        # axes and angles into numpy arrays.
+        if np.size(axes) == 0:
+            return cls.empty()
+
         axes = Vector3d(axes).unit.data
         angles = np.array(angles)
-        # trivial case of no input data
-        if axes.size * angles.size == 0:
-            return cls.empty()
         if degrees:
             angles = np.deg2rad(angles)
-        quat = cls(_conversions.ax2qu(axes, angles))
-        return quat.unit
+
+        q = _conversions.ax2qu(axes, angles)
+        q = cls(q)
+        q = q.unit
+
+        return q
+
+    @classmethod
+    def from_homochoric(
+        cls,
+        ho: Union[Vector3d, Homochoric, np.ndarray, tuple, list],
+    ) -> Quaternion:
+        r"""Create unit quaternions from homochoric vectors
+        :cite:`rowenhorst2015consistent`.
+
+        Parameters
+        ----------
+        ho
+            Homochoric vectors parallel to the axes of rotation with
+            lengths equal to
+            :math:`0.75\cdot(\theta - \sin(\theta))^{1/3}`, where
+            :math:`\theta` is the angle of rotation.
+
+        Returns
+        -------
+        q
+            Unit quaternions.
+        """
+        if np.size(ho) == 0:
+            return cls.empty()
+
+        if isinstance(ho, Vector3d):
+            ho = ho.data
+        else:
+            ho = np.atleast_2d(ho)
+            if ho.shape[-1] != 3:
+                raise ValueError("Final dimension of vector array must be 3.")
+
+        shape = ho.shape[:-1]
+        ho = ho.reshape((-1, 3))
+
+        ax = _conversions.ho2ax(ho)
+        q = _conversions.ax2qu(ax[:, :3], ax[:, 3])
+        q = q.reshape(shape + (4,))
+        q = cls(q)
+        q = q.unit
+
+        return q
+
+    @classmethod
+    def from_rodrigues(
+        cls,
+        ro: Union[np.ndarray, Vector3d, tuple, list],
+        angles: Union[np.ndarray, tuple, list, float, None] = None,
+    ) -> Quaternion:
+        r"""Create unit quaternions from Rodrigues vectors or
+        Rodrigues-Frank vectors :cite:`rowenhorst2015consistent`.
+
+        Parameters
+        ----------
+        ro
+            Rodrigues vectors :math:`\hat{\mathbf{n}}` of three
+            components. These are the components of the Rodrigues-Frank
+            vectors if the angles ``omega`` are passed.
+        angles
+            Angles :math:`\omega` of the Rodrigues-Frank vectors ``ro``,
+            one per vector. If these are not passed, ``ro`` are
+            the Rodrigues vectors.
+
+        Returns
+        -------
+        q
+            Unit quaternions.
+
+        Notes
+        -------
+        The Rodrigues-Frank vector :math:`\mathbf{\rho}` is defined as
+
+        .. math::
+
+            \mathbf{\rho} = \hat{\mathbf{n}}\tan\frac{\omega}{2}.
+
+        If the vector length is :math:`\rho = \|\mathbf{\rho}\|, the
+        angle is given by
+
+        .. math::
+
+            \omega = 2\arctan\rho.
+
+        O. Rodrigues's 1840 vector description was popularized by F. C.
+        Frank due to its useful rectilinear mapping of fundamental
+        zones, as is well-demonstrated in :cite:`frank1988orientation`.
+        However, the length of these vectors, and thus their accuracy,
+        scales with :math:`\tan(\omega/2)`. Additionally, two-fold
+        rotations produce vectors of infinite length. Thus, Frank and
+        others introduced the Rodrigues-Frank vector of length 4,
+        consisting of a unit vector followed by the scaling factor
+        :math:`\tan(\omega/2)`. This is better suited for storing data
+        or performing rotation calculations, as discussed in
+        :cite:`rowenhorst2015consistent`.
+        """
+        if np.size(ro) == 0:
+            return cls.empty()
+
+        if isinstance(ro, Vector3d):
+            ro = ro.data
+        else:
+            ro = np.atleast_2d(ro)
+            if ro.shape[-1] != 3:
+                raise ValueError("Final dimension of vector array must be 3.")
+
+        shape = ro.shape[:-1]
+        ro = ro.reshape((-1, 3))
+
+        if angles is None:
+            norm = Vector3d(ro).norm
+            if np.min(norm) < np.finfo(norm.dtype).resolution * 1000:
+                warnings.warn(
+                    "Max. estimated error is greater than 0.1%. Rodrigues vectors have "
+                    "increasing associated errors for small angle rotations. Consider "
+                    "creating quaternions in another way."
+                )
+            angles = 2 * np.arctan(norm)
+            angles = angles[:, np.newaxis]
+            ax = np.hstack((ro, angles))
+        else:
+            angles = angles.ravel()[:, np.newaxis]
+            ro_axes_angles = np.hstack((ro, angles))
+            ax = _conversions.ro2ax(ro_axes_angles)
+
+        if np.rad2deg(np.max(angles)) > 179.999:
+            warnings.warn(
+                "Highest angle is greater than 179.999 degrees. Rodrigues vectors "
+                "cannot parametrize 2-fold rotations. Consider creating quaternions"
+                " in another way."
+            )
+
+        q = cls.from_axes_angles(ax[:, :3], ax[:, 3])
+        q = q.reshape(*shape)
+        q = q.unit
+
+        return q
 
     # TODO: Remove decorator, **kwargs, and use of "convention" in 0.13
     @classmethod
@@ -398,7 +421,7 @@ class Quaternion(Object3d):
         degrees: bool = False,
         **kwargs,
     ) -> Quaternion:
-        """Initialize from Euler angle set(s)
+        """Create unit quaternions from Euler angle sets
         :cite:`rowenhorst2015consistent`.
 
         Parameters
@@ -454,7 +477,7 @@ class Quaternion(Object3d):
 
     @classmethod
     def from_matrix(cls, matrix: Union[np.ndarray, tuple, list]) -> Quaternion:
-        """Create unit quaternions from the orientation matrices
+        """Create unit quaternions from orientation matrices
         :cite:`rowenhorst2015consistent`.
 
         Parameters
@@ -490,17 +513,18 @@ class Quaternion(Object3d):
 
     @classmethod
     def from_scipy_rotation(cls, rotation: SciPyRotation) -> Quaternion:
-        """Initialize from :class:`scipy.spatial.transform.Rotation`.
+        """Create unit quaternions from
+        :class:`scipy.spatial.transform.Rotation`.
 
         Parameters
         ----------
         rotation
-            SciPy rotation(s).
+            SciPy rotations.
 
         Returns
         -------
         quaternion
-            Quaternion(s).
+            Quaternions.
 
         Notes
         -----
@@ -558,8 +582,7 @@ class Quaternion(Object3d):
         Tuple[Quaternion, np.ndarray],
         Tuple[Quaternion, float, np.ndarray],
     ]:
-        """Initialize an estimated quaternion to optimally align two
-        sets of vectors.
+        """Estimate a quaternion to optimally align two sets of vectors.
 
         This method wraps
         :meth:`~scipy.spatial.transform.Rotation.align_vectors`. See
@@ -628,7 +651,7 @@ class Quaternion(Object3d):
 
         return out[0] if len(out) == 1 else tuple(out)
 
-    # ------------------ Additional Class methods ------------------- #
+    # ------------------- Additional class methods ------------------- #
 
     @classmethod
     def triple_cross(cls, q1: Quaternion, q2: Quaternion, q3: Quaternion) -> Quaternion:
@@ -690,7 +713,7 @@ class Quaternion(Object3d):
 
     @classmethod
     def random(cls, shape: Union[int, tuple] = (1,)) -> Quaternion:
-        """Return random quaternions.
+        """Create random unit quaternions.
 
         Parameters
         ----------
@@ -734,13 +757,13 @@ class Quaternion(Object3d):
         q[..., 0] = 1
         return cls(q)
 
-    # -------------------- All "to_*" functions ---------------_----- #
+    # --------------------- All "to_*" functions --------------------- #
 
     # TODO: Remove decorator and **kwargs in 0.13
     @deprecated_argument("convention", since="0.9", removal="0.13")
     def to_euler(self, degrees: bool = False, **kwargs) -> np.ndarray:
-        r"""Return the normalized quaternions as Euler angles in the
-        Bunge convention :cite:`rowenhorst2015consistent`.
+        r"""Return the unit quaternions as Euler angles in the Bunge
+        convention :cite:`rowenhorst2015consistent`.
 
         Parameters
         ----------
@@ -762,7 +785,7 @@ class Quaternion(Object3d):
         return eu
 
     def to_matrix(self) -> np.ndarray:
-        """Return the normalized quaternions as orientation matrices
+        """Return the unit quaternions as orientation matrices
         :cite:`rowenhorst2015consistent`.
 
         Returns
@@ -784,132 +807,132 @@ class Quaternion(Object3d):
         om = _conversions.qu2om(self.unit.data)
         return om
 
-    def to_axes_angles(self, degrees: bool = False) -> Tuple[Vector3d, np.ndarray]:
-        """Return an axis-angle representation of the normalized
-        quaternions :cite:`rowenhorst2015consistent`.
+    def to_axes_angles(self) -> AxAngle:
+        r"""Return the unit quaternions as axis-angle vectors
+        :cite:`rowenhorst2015consistent`.
+
+        Returns
+        -------
+        ax
+            Axis-angle vectors with magnitude :math:`\theta` equal to
+            the angle of rotation.
+
+        Examples
+        --------
+        A 3-fold rotation around the [111] axis
+
+        >>> from orix.quaternion import Quaternion
+        >>> q = Quaternion([0.5, 0.5, 0.5, 0.5])
+        >>> ax = q.to_axes_angles()
+        >>> ax
+        AxAngle (1,)
+        [[1.2092 1.2092 1.2092]]
+        >>> ax.angle
+        array([[120.]])
+        """
+        axes, angles = _conversions.qu2ax(self.unit.data)
+        ax = AxAngle(axes * angles)
+        return ax
+
+    def to_rodrigues(self, frank: bool = False) -> Union[Rodrigues, np.ndarray]:
+        r"""Return the unit quaternions as Rodrigues or Rodrigues-Frank
+         vectors :cite:`rowenhorst2015consistent`.
 
         Parameters
         ----------
-        degrees
-            If True, the angles are given in degrees. Default is False.
+        frank
+            Whether to return Rodrigues vectors scaled by
+            :math:`\tan(\theta/2)`, where :math:`\theta` is the angle of
+            rotation, or Rodrigues-Frank vectors scaled by
+            :math:`\omega = 2\arctan(|\rho|)` in an array.
 
         Returns
         -------
-        axis
-            The axes of rotation.
-        angle
-            The angles of rotation.
+        ro
+            Vectors :math:`\hat{\mathbf{n}}` parallel to the axis of
+            rotation if ``frank=False`` or an array of four-component
+            vectors if ``frank=True``.
 
         Examples
         --------
-        >>> # 3-fold rotation around the 111 axis
-        >>> quat = Quaternion([0.5,0.5,0.5,0.5])
-        >>> axis, angle = quat.to_axes_angles()
-        >>> axis,np.rad2deg(angle)
+        A 3-fold rotation around the [111] axis
 
-        """
-        axis, angle = _conversions.qu2ax(self.data)
-        if degrees:
-            angle = angle * 180 / np.pi
-        return axis, angle
-
-    def to_rodrigues(self) -> Vector3d:
-        r"""Returns the neo-Eulerian Rodrigues representation of the
-        normalized quaternion(s) as a Vector3D object.
-
-        Returns
-        -------
-        rod
-            a vector3D object parallel to the quaternion's axis of
-            rotation, with a magnitude of :math:`\tan(angle/2)` .
-
-        Examples
-        --------
-
-        >>> # 3-fold rotation around the 111 axis
-        >>> quat = Quaternion([0.5,0.5,0.5,0.5])
-        >>> rod = quat.to_rodrigues()
-        >>> rod
-        Vector3d (1,)
+        >>> from orix.quaternion import Quaternion
+        >>> q = Quaternion.from_axes_angles([1, 1, 1], 120, degrees=True)
+        >>> ro1 = q.to_rodrigues()
+        >>> ro1
+        Rodrigues (1,)
         [[1. 1. 1.]]
+        >>> ro1.norm
+        1.7320508075688776
+        >>> ro2 = q.to_rodrigues(frank=True)
+        array([[0.57735027, 0.57735027, 0.57735027, 1.73205081]])
+        >>> np.linalg.norm(ro2[:, :3])
+        1.0
 
-        >>> # 4-fold rotation around the 111 axis
-        >>> quat = Quaternion([0.9239, 0.2209, 0.2209, 0.2209])
-        >>> rod = quat.to_rodrigues()
-        >>> rod
-        Vector3d (1,)
+        A 45:math:`^{\circ}` rotation around the [111] axis
+
+        >>> q2 = Quaternion.from_axes_angles([1, 1, 1], 45, degrees=True)
+        >>> ro3 = q2.to_rodrigues()
+        >>> ro3
+        Rodrigues (1,)
         [[0.2391 0.2391 0.2391]]
 
         Notes
         -----
-        This function returns the 3D vector representation of a rotation
-        originally proposed by Olinde Rodrigues. These vectors are often
-        used for plotting orientation data, as they create isomorphic
-        (though not volume preserving) plots, and fundamental zones have
-        rectilinear boundaries. This is well-demonstrated in the following
-        paper:
-            https://doi.org/10.1007/BF02649253
-        For the 4D Rodrigues-Frank (axis, angle) vector discussed in
-            :cite:`rowenhorst2015consistent`,
-        users should instead use `Quaternion.to_rodrigues_frank`.
+        Rodrigues vectors, originally proposed by O. Rodrigues, are
+        often used for plotting orientations as they create isomorphic
+        (though not volume-preserving) plots and form fundamental zones
+        with rectilinear boundaries. These features are
+        well-demonstrated in :cite:`frank1988orientation`. See
+        :cite:`rowenhorst2015consistent` for examples of usage of
+        Rodrigues-Frank vectors.
         """
-        ax = self.axis.unit
-        rod = ax * np.tan(self.angle / 2)
-        return rod
+        q = self.unit
+        if not frank:
+            ro = q.axis * np.tan(self.angle / 2)
+            ro = Rodrigues(ro)
+        else:
+            axes, angles = _conversions.qu2ax(q.data)
+            axes_angles = np.concatenate((axes, angles), axis=-1)
+            ro = _conversions.ax2ro(axes_angles)
+        return ro
 
-    def to_rodrigues_frank(self) -> np.ndarray:
-        r"""Returns the Rodrigues-Frank :math:`(n_1,n_2,n_3, \omega)`
-        vector as presented in :cite:`rowenhorst2015consistent`.
+    def to_homochoric(self) -> Homochoric:
+        r"""Return the unit quaternions as homochoric vectors
+        :cite:`rowenhorst2015consistent`.
 
         Returns
         -------
-        rod
-            a numpy array of shape (...,4)
-
-        Notes
-        -----
-        This function returns the 4D vector representation of a rotation
-        proposed by C.S. Frank, the uses of which are discussed further in
-        :cite:`rowenhorst2015consistent`. Users looking to directly create
-        3D plots of orientation data in Rodrigues space should instead use
-        `Quaternion.to_rodrigues`.
-        """
-        ax = np.concatenate(_conversions.qu2ax(self.unit.data), axis=-1)
-        rf = _conversions.ax2ro(ax)
-        return rf
-
-    def to_homochoric(self) -> Vector3d:
-        r"""Return the neo-Eulerian homochoric vector representation of
-        the normalized quaternions :cite:`rowenhorst2015consistent`.
-
-        Returns
-        -------
-        vec
-            The axes of rotation, with lengths equal to
-            :math:`0.75\cdot(\theta - \sin(\theta))^{1/3}`.
+        ho
+            Homochoric vectors parallel to the axes of rotation with
+            lengths equal to
+            :math:`0.75\cdot(\theta - \sin(\theta))^{1/3}`, where
+            :math:`\theta` is the angle of rotation.
 
         Examples
         --------
-        >>> # 3-fold rotation around the 111 axis
-        >>> quat = Quaternion([0.5,0.5,0.5,0.5])
-        >>> rod = quat.to_homochoric()
-        >>> rod
-        Vector3d (1,)
+        A 3-fold rotation about the [111] axis
+
+        >>> from orix.quaternion import Quaternion
+        >>> q = Quaternion.from_axes_angles([1, 1, 1], 120, degrees=True)
+        >>> ho = q.to_homochoric()
+        >>> ho
+        Homochoric (1,)
         [[0.5618 0.5618 0.5618]]
 
         Notes
         -----
-        This is often used as a plotting tool, as it produces an
-        isomorphic (though not angle-preserving) mapping from the
-        non-euclidean orientation space into cartesian coordinates.
-        Additionally, unlike Rodrigues vectors, all rotations map into a
-        finite space, bounded by a sphere of radius :math:`\pi`.
+        Homochoric vectors are often used for plotting orientations as
+        they create an isomorphic (though not angle-preserving) mapping
+        from the non-euclidean orientation space into Cartesian
+        coordinates. Additionally, unlike Rodrigues vectors, all
+        rotations map into a finite space, bounded by a sphere of radius
+        :math:`\pi`.
         """
-        ax = self.axis.unit
-        ang = self.angle
-        magnitude = (0.75 * (ang - np.sin(ang))) ** (1 / 3)
-        vec = ax * magnitude
-        return vec
+        ho = _conversions.qu2ho(self.unit.data)
+        ho = Homochoric(ho)
+        return ho
 
     # -------------------- Other public functions ------------------- #
 

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -188,7 +188,7 @@ class Rotation(Quaternion):
 
         See Also
         --------
-        from_neo_euler
+        from_homochoric, from_rodrigues
         """
         return super().from_axes_angles(axes, angles, degrees)
 
@@ -482,8 +482,9 @@ class Rotation(Quaternion):
             Indices to reconstruct the flattened rotations from the
             initial rotations. Only returned if ``return_inverse=True``.
         """
-        if len(self.data) == 0:
-            return self.__class__(self.data)
+        if self.size == 0:
+            return self.empty()
+
         r = self.flatten()
 
         if antipodal:

--- a/orix/quaternion/symmetry.py
+++ b/orix/quaternion/symmetry.py
@@ -25,7 +25,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from orix.quaternion.rotation import Rotation
-from orix.vector import AxAngle, Vector3d
+from orix.vector import Vector3d
 
 
 class Symmetry(Rotation):

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -724,6 +724,215 @@ loop_
     gc.collect()
 
 
+# ---------- Rotation representations for conversion tests ----------- #
+# NOTE to future test writers on unittest data:
+# All the data below can be recreated using 3Drotations, which is
+# available at
+# https://github.com/marcdegraef/3Drotations/blob/master/src/python.
+# 3Drotations is an expanded implementation of the rotation conversions
+# laid out in Rowenhorst et al. (2015), written by a subset of the
+# original authors.
+# Note, however, that orix differs from 3Drotations in its handling of
+# some edge cases. Software using 3Drotations (for example, Dream3D and
+# EBSDLib), handle rounding and other corrections after converting,
+# whereas orix accounts for them during. The first three angles in each
+# set are tests of these edge cases, and will therefore differ between
+# orix and 3Drotations. For all other angles, the datasets can be
+# recreated using a variation of:
+#   np.around(rotlib.qu2{insert_new_representation_here}(qu), 4).
+# This consistently gives results with four decimals of accuracy.
+
+
+@pytest.fixture
+def cubochoric_coordinates():
+    # fmt: off
+    return np.array(
+        [
+            [np.pi ** (2 / 3) / 2 + 1e-7,    1,    1],
+            [                          0,    0,    0],
+            [                     1.0725,    0,    0],
+            [                          0,    0,    1],
+            [                        0.1,  0.1,  0.2],
+            [                        0.1,  0.1, -0.2],
+            [                        0.5,  0.2,  0.1],
+            [                       -0.5, -0.2,  0.1],
+            [                        0.2,  0.5,  0.1],
+            [                        0.2, -0.5,  0.1],
+        ],
+        dtype=np.float64,
+    )
+    # fmt: on
+
+
+@pytest.fixture
+def homochoric_vectors():
+    # fmt: off
+    return np.array(
+        [
+            [      0,       0,       0],
+            [      0,       0,       0],
+            [ 1.3307,       0,       0],
+            [      0,       0,  1.2407],
+            [ 0.0785,  0.0785,  0.2219],
+            [ 0.0785,  0.0785, -0.2219],
+            [ 0.5879,  0.1801,  0.0827],
+            [-0.5879, -0.1801,  0.0827],
+            [ 0.1801,  0.5879,  0.0827],
+            [ 0.1801, -0.5879,  0.0827],
+        ],
+        dtype=np.float64,
+    )
+    # fmt: on
+
+
+@pytest.fixture
+def axis_angle_pairs():
+    # fmt: off
+    return np.array(
+        [
+            [      0,       0,       1,      0],
+            [      0,       0,       1,      0],
+            [      1,       0,       0,  np.pi],
+            [      0,       0,       1, 2.8418],
+            [ 0.3164,  0.3164,  0.8943, 0.4983],
+            [ 0.3164,  0.3164, -0.8943, 0.4983],
+            [ 0.9476,  0.2903,  0.1333, 1.2749],
+            [-0.9476, -0.2903,  0.1333, 1.2749],
+            [ 0.2903,  0.9476,  0.1333, 1.2749],
+            [ 0.2903, -0.9476,  0.1333, 1.2749],
+        ],
+        dtype=np.float64,
+    )
+    # fmt: on
+
+
+@pytest.fixture
+def rodrigues_vectors():
+    # fmt: off
+    return np.array(
+        [
+            [      0,       0,       1,      0],
+            [      0,       0,       1,      0],
+            [      1,       0,       0, np.inf],
+            [      0,       0,       1, 6.6212],
+            [ 0.3164,  0.3164,  0.8943, 0.2544],
+            [ 0.3164,  0.3164, -0.8943, 0.2544],
+            [ 0.9476,  0.2903,  0.1333, 0.7406],
+            [-0.9476, -0.2903,  0.1333, 0.7406],
+            [ 0.2903,  0.9476,  0.1333, 0.7406],
+            [ 0.2903, -0.9476,  0.1333, 0.7406]
+        ],
+        dtype=np.float64,
+    )
+    # fmt: on
+
+
+@pytest.fixture
+def orientation_matrices():
+    # fmt: off
+    return np.array(
+        [
+            [
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+            ],
+            [
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+            ],
+            [
+                [1,  0,  0],
+                [0, -1,  0],
+                [0,  0, -1],
+            ],
+            [
+                [-0.9554, -0.2953, 0],
+                [ 0.2953, -0.9554, 0],
+                [      0,       0, 1],
+            ],
+            [
+                [ 0.8906, -0.4152,  0.1856],
+                [ 0.4396,  0.8906, -0.1168],
+                [-0.1168,  0.1856,  0.9757],
+            ],
+            [
+                [ 0.8906, 0.4396,  0.1168],
+                [-0.4152, 0.8906, -0.1856],
+                [-0.1856, 0.1168,  0.9757],
+            ],
+            [
+                [ 0.9277, 0.0675,  0.3672],
+                [ 0.3224, 0.3512, -0.879 ],
+                [-0.1883, 0.9339,  0.3041],
+            ],
+            [
+                [0.9277,  0.0675, -0.3672],
+                [0.3224,  0.3512,  0.879 ],
+                [0.1883, -0.9339,  0.3041],
+            ],
+            [
+                [ 0.3512, 0.0675,  0.9339],
+                [ 0.3224, 0.9277, -0.1883],
+                [-0.879 , 0.3672,  0.3041],
+            ],
+            [
+                [ 0.3512, -0.3224, -0.879 ],
+                [-0.0675,  0.9277, -0.3672],
+                [ 0.9339,  0.1883,  0.3041],
+            ],
+        ],
+        dtype=np.float64
+    )
+    # fmt: on
+
+
+@pytest.fixture
+def quaternions_conversions():
+    # fmt: off
+    return np.array(
+        [
+            [     1,       0,       0,       0],
+            [     1,       0,       0,       0],
+            [     0,       1,       0,       0],
+            [0.1493,       0,       0,  0.9888],
+            [0.9691,  0.0780,  0.0780,  0.2205],
+            [0.9691,  0.0780,  0.0780, -0.2205],
+            [0.8036,  0.5640,  0.1728,  0.0793],
+            [0.8036, -0.5640, -0.1728,  0.0793],
+            [0.8036,  0.1728,  0.5640,  0.0793],
+            [0.8036,  0.1728, -0.5640,  0.0793],
+        ],
+        dtype=np.float64,
+    )
+    # fmt: on
+
+
+@pytest.fixture
+def euler_angles():
+    # fmt: off
+    return np.array(
+        [
+            [     0,      0,      0],
+            [     0,      0,      0],
+            [     0, 3.1416,      0],
+            [3.4413,      0,      0],
+            [3.7033, 0.2211, 2.1325],
+            [4.1507, 0.2211, 2.5799],
+            [3.3405, 1.2618, 2.7459],
+            [0.1989, 1.2618, 5.8875],
+            [4.3167, 1.2618, 1.7697],
+            [1.7697, 1.2618, 4.3167],
+        ],
+        dtype=np.float64,
+    )
+    # fmt: on
+
+
+# ------- End of rotation representations for conversion tests ------- #
+
+
 @pytest.fixture(autouse=True)
 def import_to_namespace(doctest_namespace):
     """Make :mod:`numpy` and :mod:`matplotlib.pyplot` available in

--- a/orix/tests/quaternion/test_conversions.py
+++ b/orix/tests/quaternion/test_conversions.py
@@ -16,12 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
-import warnings
-
 import numpy as np
 import pytest
 
-from orix.quaternion import Orientation, Quaternion, Rotation
+from orix.quaternion import Orientation
 from orix.quaternion._conversions import (
     ax2qu,
     ax2qu_2d,
@@ -56,6 +54,9 @@ from orix.quaternion._conversions import (
     qu2eu,
     qu2eu_2d,
     qu2eu_single,
+    qu2ho,
+    qu2ho_2d,
+    qu2ho_single,
     qu2om,
     qu2om_2d,
     qu2om_single,
@@ -63,434 +64,318 @@ from orix.quaternion._conversions import (
     ro2ax_2d,
     ro2ax_single,
 )
-from orix.quaternion.symmetry import C1, Oh
-
-
-# NOTE to future test writers on unittest data:
-# All the data below can be recreated using 3Drotations, which is available
-# at https://github.com/marcdegraef/3Drotations/blob/master/src/python
-# 3Drotations is an expanded implementation of the rotation conversions
-# laid out in 2015 Rowenhorst et et. al., written by a subset of the
-# original authors.
-# Note, however, that orix differs from 3Drotations in its handling of some
-# edge cases. Software using 3Drotations (for example, Dream3D abd EBSDLib),
-# handle rounding and other corrections after converting, whereas Orix
-# accounts for them during. The first three angles in each set are tests of
-# these edge cases, and will therefore differ between orix and 3Drotations.
-# For all other angles, the datasets can be recreated using a variation of:
-#   np.around(rotlib.qu2{insert_new_representation_here}(qu),4)
-# this consistently gives results with 4 decimal of accuracy.
-@pytest.fixture
-def cubochoric_coordinates():
-    return np.array(
-        [
-            [np.pi ** (2 / 3) / 2 + 1e-7, 1, 1],
-            [0, 0, 0],
-            [1.0725, 0, 0],
-            [0, 0, 1],
-            [0.1, 0.1, 0.2],
-            [0.1, 0.1, -0.2],
-            [0.5, 0.2, 0.1],
-            [-0.5, -0.2, 0.1],
-            [0.2, 0.5, 0.1],
-            [0.2, -0.5, 0.1],
-        ],
-        dtype=np.float64,
-    )
-
-
-@pytest.fixture
-def homochoric_vectors():
-    # np.around(rotlib.qu2ho(qu),4)
-    return np.array(
-        [
-            [0, 0, 0],
-            [0, 0, 0],
-            [1.3307, 0, 0],
-            [0, 0, 1.2407],
-            [0.0785, 0.0785, 0.2219],
-            [0.0785, 0.0785, -0.2219],
-            [0.5879, 0.1801, 0.0827],
-            [-0.5879, -0.1801, 0.0827],
-            [0.1801, 0.5879, 0.0827],
-            [0.1801, -0.5879, 0.0827],
-        ],
-        dtype=np.float64,
-    )
-
-
-@pytest.fixture
-def axis_angle_pairs():
-    # np.around(rotlib.qu2ax(qu),4)
-    return np.array(
-        [
-            [0, 0, 1, 0],
-            [0, 0, 1, 0],
-            [1, 0, 0, np.pi],
-            [0, 0, 1, 2.8418],
-            [0.3164, 0.3164, 0.8943, 0.4983],
-            [0.3164, 0.3164, -0.8943, 0.4983],
-            [0.9476, 0.2903, 0.1333, 1.2749],
-            [-0.9476, -0.2903, 0.1333, 1.2749],
-            [0.2903, 0.9476, 0.1333, 1.2749],
-            [0.2903, -0.9476, 0.1333, 1.2749],
-        ],
-        dtype=np.float64,
-    )
-
-
-@pytest.fixture
-def rodrigues_vectors():
-    # np.around(rotlib.qu2ro(qu),4)
-    return np.array(
-        [
-            [0, 0, 1, 0],
-            [0, 0, 1, 0],
-            [1, 0, 0, np.inf],
-            [0, 0, 1, 6.6212],
-            [0.3164, 0.3164, 0.8943, 0.2544],
-            [0.3164, 0.3164, -0.8943, 0.2544],
-            [0.9476, 0.2903, 0.1333, 0.7406],
-            [-0.9476, -0.2903, 0.1333, 0.7406],
-            [0.2903, 0.9476, 0.1333, 0.7406],
-            [0.2903, -0.9476, 0.1333, 0.7406],
-        ],
-        dtype=np.float64,
-    )
-
-
-@pytest.fixture
-def orthogonal_matrices():
-    # np.around(rotlib.qu2om(qu),4)
-    return np.array(
-        [
-            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
-            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
-            [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]],
-            [
-                [-0.9554, -0.2953, 0.0000],
-                [0.2953, -0.9554, 0.0000],
-                [0.0000, 0.0000, 1.0000],
-            ],
-            [
-                [0.8906, -0.4152, 0.1856],
-                [0.4396, 0.8906, -0.1168],
-                [-0.1168, 0.1856, 0.9757],
-            ],
-            [
-                [0.8906, 0.4396, 0.1168],
-                [-0.4152, 0.8906, -0.1856],
-                [-0.1856, 0.1168, 0.9757],
-            ],
-            [
-                [0.9277, 0.0675, 0.3672],
-                [0.3224, 0.3512, -0.879],
-                [-0.1883, 0.9339, 0.3041],
-            ],
-            [
-                [0.9277, 0.0675, -0.3672],
-                [0.3224, 0.3512, 0.879],
-                [0.1883, -0.9339, 0.3041],
-            ],
-            [
-                [0.3512, 0.0675, 0.9339],
-                [0.3224, 0.9277, -0.1883],
-                [-0.879, 0.3672, 0.3041],
-            ],
-            [
-                [0.3512, -0.3224, -0.879],
-                [-0.0675, 0.9277, -0.3672],
-                [0.9339, 0.1883, 0.3041],
-            ],
-        ]
-    )
-
-
-@pytest.fixture
-def quaternions_conversions():
-    return np.array(
-        [
-            [1, 0, 0, 0],
-            [1, 0, 0, 0],
-            [0, 1, 0, 0],
-            [0.1493, 0, 0, 0.9888],
-            [0.9691, 0.0780, 0.0780, 0.2205],
-            [0.9691, 0.0780, 0.0780, -0.2205],
-            [0.8036, 0.5640, 0.1728, 0.0793],
-            [0.8036, -0.5640, -0.1728, 0.0793],
-            [0.8036, 0.1728, 0.5640, 0.0793],
-            [0.8036, 0.1728, -0.5640, 0.0793],
-        ],
-        dtype=np.float64,
-    )
-
-
-@pytest.fixture
-def euler_angles():
-    return np.array(
-        [
-            [0.0, 0.0, 0.0],
-            [0.0, 0.0, 0.0],
-            [0.0, 3.1416, 0.0],
-            [3.4413, 0.0, 0.0],
-            [3.7033, 0.2211, 2.1325],
-            [4.1507, 0.2211, 2.5799],
-            [3.3405, 1.2618, 2.7459],
-            [0.1989, 1.2618, 5.8875],
-            [4.3167, 1.2618, 1.7697],
-            [1.7697, 1.2618, 4.3167],
-        ],
-        dtype=np.float64,
-    )
+from orix.quaternion.symmetry import Oh
 
 
 class TestRotationConversions:
     """Tests of conversions between rotation representations.
 
     Functions are accelerated with Numba, so both the Numba and Python
-    versions of the function are tested.
+    versions of the functions are tested.
     """
 
-    def test_eu2qu2eu(self, quaternions_conversions, euler_angles):
+    def test_eu2qu2eu(self, euler_angles, quaternions_conversions):
         qu_64 = quaternions_conversions
         eu_64 = euler_angles
-        qu_32 = qu_64.astype(np.float32)
-        eu_32 = eu_64.astype(np.float32)
-        # single
+        qu_32_nd = qu_64.astype(np.float32).reshape((2, 5, 4))
+        eu_32_nd = eu_64.astype(np.float32).reshape((2, 5, 3))
+
+        # Single
         for qu, eu in zip(qu_64, eu_64):
             assert np.allclose(qu2eu_single.py_func(qu), eu, atol=1e-4)
             assert np.allclose(eu2qu_single.py_func(eu), qu, atol=1e-4)
-        # 2d
+
+        # 2D
         assert np.allclose(qu2eu_2d.py_func(qu_64), eu_64, atol=1e-4)
         assert np.allclose(eu2qu_2d.py_func(eu_64), qu_64, atol=1e-4)
-        # nd and jit
-        assert np.allclose(eu2qu(eu_64), qu_64, atol=1e-4)
-        assert np.allclose(qu2eu(qu_64), eu_64, atol=1e-4)
-        # nd_float32
-        assert np.allclose(qu2eu(qu_32), eu_32, atol=1e-4)
-        assert np.allclose(eu2qu(eu_32), qu_32, atol=1e-4)
+
+        # ND and jit
+        qu_64_nd = qu_64.reshape((2, 5, 4))
+        eu_64_nd = eu_64.reshape((2, 5, 3))
+        assert np.allclose(eu2qu(eu_64_nd), qu_64_nd, atol=1e-4)
+        assert np.allclose(qu2eu(qu_64_nd), eu_64_nd, atol=1e-4)
+
+        # ND float32
+        assert np.allclose(qu2eu(qu_32_nd), eu_32_nd, atol=1e-4)
+        assert np.allclose(eu2qu(eu_32_nd), qu_32_nd, atol=1e-4)
+
         # Symmetry-preserving
         ori = Orientation.from_euler(eu_64[-1], Oh)
-        assert np.all(ori._symmetry[0] == C1)
-        assert np.all(ori._symmetry[1] == Oh)
+        assert ori.symmetry == Oh
         assert np.allclose(ori.data[0], qu_64[-1], atol=1e-4)
 
     def test_get_pyramid(self, cubochoric_coordinates):
         """Cubochoric coordinates situated in expected pyramid."""
         cu_64 = cubochoric_coordinates
-        pyramid = [3, 1, 3, 1, 1, 2, 3, 4, 5, 6]
-        # single
+        pyramid = np.array([3, 1, 3, 1, 1, 2, 3, 4, 5, 6])
+
+        # Single
         for xyz, p in zip(cu_64, pyramid):
             assert get_pyramid_single.py_func(xyz) == p
-        # 2d
-        assert all(get_pyramid_2d.py_func(cu_64) == pyramid)
-        # nd
-        assert all(get_pyramid(cu_64) == pyramid)
+
+        # 2D
+        assert np.allclose(get_pyramid_2d.py_func(cu_64), pyramid)
+
+        # ND
+        cu_64_nd = cu_64.reshape((5, 2, 3))
+        assert np.allclose(get_pyramid(cu_64_nd), pyramid)
 
     def test_cu2ho(self, cubochoric_coordinates, homochoric_vectors):
-        # single
-        for cu, ho in zip(cubochoric_coordinates, homochoric_vectors):
+        cu_64 = cubochoric_coordinates
+        ho_64 = homochoric_vectors
+
+        # Single
+        for cu, ho in zip(cu_64, ho_64):
             assert np.allclose(cu2ho_single.py_func(cu), ho, atol=1e-4)
-        # 2d
-        assert np.allclose(
-            cu2ho_2d.py_func(cubochoric_coordinates), homochoric_vectors, atol=1e-4
-        )
-        # nd
-        assert np.allclose(cu2ho(cubochoric_coordinates), homochoric_vectors, atol=1e-4)
-        # nd_float32
-        cu_32 = cubochoric_coordinates.astype(np.float32)
-        ho_32 = homochoric_vectors.astype(np.float32)
-        assert np.allclose(cu2ho(cu_32), ho_32, atol=1e-4)
+
+        # 2D
+        assert np.allclose(cu2ho_2d.py_func(cu_64), ho_64, atol=1e-4)
+
+        # ND
+        cu_64_nd = cu_64.reshape((5, 2, 3))
+        ho_64_nd = ho_64.reshape((5, 2, 3))
+        assert np.allclose(cu2ho(cu_64_nd), ho_64_nd, atol=1e-4)
+
+        # ND float32
+        cu_32_nd = cu_64_nd.astype(np.float32)
+        ho_32_nd = ho_64_nd.astype(np.float32)
+        assert np.allclose(cu2ho(cu_32_nd), ho_32_nd, atol=1e-4)
 
     def test_ho2ax(self, homochoric_vectors, axis_angle_pairs):
-        # single
-        for ho, ax in zip(homochoric_vectors, axis_angle_pairs):
+        ho_64 = homochoric_vectors
+        ax_64 = axis_angle_pairs
+
+        # Single
+        for ho, ax in zip(ho_64, ax_64):
             assert np.allclose(ho2ax_single.py_func(ho), ax, atol=1e-4)
-        # 2d
-        assert np.allclose(
-            ho2ax_2d.py_func(homochoric_vectors), axis_angle_pairs, atol=1e-4
-        )
-        # nd
-        assert np.allclose(ho2ax(homochoric_vectors), axis_angle_pairs, atol=1e-4)
-        # nd_float32
-        axang_32 = axis_angle_pairs.astype(np.float32)
-        ho_32 = homochoric_vectors.astype(np.float32)
-        assert np.allclose(ho2ax(ho_32), axang_32, atol=1e-4)
+
+        # 2D
+        assert np.allclose(ho2ax_2d.py_func(ho_64), ax_64, atol=1e-4)
+
+        # ND
+        ho_64_nd = ho_64.reshape((2, 5, 3))
+        ax_64_nd = ax_64.reshape((2, 5, 4))
+        assert np.allclose(ho2ax(ho_64_nd), ax_64_nd, atol=1e-4)
+
+        # ND float32
+        ho_32_nd = ho_64_nd.astype(np.float32)
+        ax_32_nd = ax_64_nd.astype(np.float32)
+        assert np.allclose(ho2ax(ho_32_nd), ax_32_nd, atol=1e-4)
 
     def test_ax2ro2ax(
         self, axis_angle_pairs, rodrigues_vectors, quaternions_conversions
     ):
         ax_64 = axis_angle_pairs
         ro_64 = rodrigues_vectors
-        ax_32 = ax_64.astype(np.float32)
-        ro_32 = ro_64.astype(np.float32)
-        # single
+
+        # Single
         for ax, ro in zip(ax_64, ro_64):
             assert np.allclose(ax2ro_single.py_func(ax), ro, atol=1e-4)
             assert np.allclose(ro2ax_single.py_func(ro), ax, atol=1e-4)
-        # 2d
+
+        # 2D
         assert np.isinf(ax2ro_single.py_func(np.array([0, 0, 0, np.pi]))[3])
         assert np.allclose(ax2ro_2d.py_func(ax_64), ro_64, atol=1e-4)
         assert np.allclose(ro2ax_2d.py_func(ro_64), ax_64, atol=1e-4)
-        # nd
-        assert np.allclose(ax2ro(ax_64), ro_64, atol=1e-4)
-        assert np.allclose(ro2ax(ro_64), ax_64, atol=1e-4)
-        # nd_float32
-        assert np.allclose(ax2ro(ax_32), ro_32, atol=1e-4)
-        assert np.allclose(ro2ax(ro_32), ax_32, atol=1e-4)
-        # Test Quaternion class implementations
-        quat1 = Quaternion(quaternions_conversions)
-        quat2 = Quaternion.from_rodrigues_frank(ro_64)
-        assert np.allclose(quat1.data, quat2.data, atol=1e-4)
-        rf_from_quat = quat1.to_rodrigues_frank()
-        assert np.allclose(rf_from_quat[4:], ro_64[4:], atol=1e-4)
-        assert Quaternion.from_rodrigues_frank([]).size == 0
-        # Test warnings for Quaternion class
-        with pytest.warns(UserWarning, match="179.99"):
-            Quaternion.from_rodrigues([1e15, 1e15, 1e10])
-        with pytest.warns(UserWarning, match="Max."):
-            Quaternion.from_rodrigues([0, 0, 1e-16])
-        with pytest.raises(ValueError, match="rodrigues_frank"):
-            Quaternion.from_rodrigues([1, 2, 3, 4])
-        with pytest.raises(ValueError, match="instead"):
-            Quaternion.from_rodrigues_frank([1, 2, 3])
+
+        # ND
+        ax_64_nd = ax_64.reshape((2, 5, 4))
+        ro_64_nd = ro_64.reshape((2, 5, 4))
+        assert np.allclose(ax2ro(ax_64_nd), ro_64_nd, atol=1e-4)
+        assert np.allclose(ro2ax(ro_64_nd), ax_64_nd, atol=1e-4)
+
+        # ND float32
+        ax_32_nd = ax_64_nd.astype(np.float32)
+        ro_32_nd = ro_64_nd.astype(np.float32)
+        assert np.allclose(ax2ro(ax_32_nd), ro_32_nd, atol=1e-4)
+        assert np.allclose(ro2ax(ro_32_nd), ax_32_nd, atol=1e-4)
 
     def test_ax2qu2ax(self, axis_angle_pairs, quaternions_conversions):
         ax_64 = axis_angle_pairs
         qu_64 = quaternions_conversions
-        ax_32 = ax_64.astype(np.float32)
-        qu_32 = qu_64.astype(np.float32)
-        axis_32 = ax_32[:, :3]
-        ang_32 = ax_32[:, 3]
-        # single
+
+        # Single
         for ax, qu in zip(ax_64, qu_64):
             assert np.allclose(ax2qu_single.py_func(ax), qu, atol=1e-4)
             assert np.allclose(qu2ax_single.py_func(qu), ax, atol=2e-4)
-        # test conversion of souther hemisphere quaternion
-        southern_qu = np.array([-1, 1, 1, 0], dtype=np.float64)
-        south_ax = ax2qu_single(southern_qu)
-        assert np.allclose(south_ax, np.array([1, 0, 0, 0]), atol=1e-4)
-        # 2d
+
+        # Test conversion of lower hemisphere quaternion
+        qu_lower = np.array([-1, 1, 1, 0], dtype=np.float64)
+        ax_lower = ax2qu_single(qu_lower)
+        assert np.allclose(ax_lower, np.array([1, 0, 0, 0]), atol=1e-4)
+
+        # 2D
         assert np.allclose(ax2qu_2d.py_func(ax_64), qu_64, atol=1e-4)
         assert np.allclose(qu2ax_2d.py_func(qu_64), ax_64, atol=2e-4)
-        # nd
-        assert np.allclose(ax2qu(ax_64[:, :3], ax_64[:, 3]), qu_64, atol=1e-4)
-        axang = np.hstack(qu2ax(qu_64))
-        assert np.allclose(axang, ax_64, atol=2e-4)
-        # nd_float32
-        assert np.allclose(ax2qu(axis_32, ang_32), qu_32, atol=1e-4)
-        axang_32 = np.hstack(qu2ax(qu_32))
-        assert np.allclose(axang_32, ax_32, atol=2e-4)
-        # make sure bad data causes the expected errors
-        with pytest.raises(ValueError, match="(...,3)"):
-            ax2qu(axis_32.T, ang_32)
-        with pytest.raises(ValueError, match="(6, 3)"):
-            ax2qu(axis_32[:6,], ang_32[:8])
-        with pytest.raises(ValueError, match="(...,4)"):
+
+        # ND
+        ax_64_nd = ax_64.reshape((2, 5, 4))
+        qu_64_nd = qu_64.reshape((2, 5, 4))
+        assert np.allclose(
+            ax2qu(ax_64_nd[..., :3], ax_64_nd[..., 3]), qu_64_nd, atol=1e-4
+        )
+        ax_64_nd_out = np.dstack(qu2ax(qu_64_nd))
+        assert np.allclose(ax_64_nd_out, ax_64_nd, atol=2e-4)
+
+        # ND float32
+        ax_32_nd = ax_64_nd.astype(np.float32)
+        qu_32_nd = qu_64_nd.astype(np.float32)
+        axes_32_nd = ax_32_nd[..., :3]
+        angles_32_nd = ax_32_nd[..., 3]
+        assert np.allclose(ax2qu(axes_32_nd, angles_32_nd), qu_32_nd, atol=1e-4)
+        ax_32_nd_out = np.dstack(qu2ax(qu_32_nd))
+        assert np.allclose(ax_32_nd_out, ax_32_nd, atol=2e-4)
+
+        # Make sure bad data causes the expected errors
+        with pytest.raises(ValueError, match="Final dimension of axes array must be 3"):
+            ax2qu(axes_32_nd.T, angles_32_nd)
+        with pytest.raises(
+            ValueError,
+            match=r"The dimensions of axes \(2, 3\) and angles \(2, 2\) are ",
+        ):
+            ax2qu(axes_32_nd[:, :3], angles_32_nd[:, :2])
+        with pytest.raises(
+            ValueError, match="Final dimension of quaternion array must be 4"
+        ):
             qu2ax(qu_64[:, :3])
-        # Check Quaternion and Orientation class features
-        ori = Orientation.from_axes_angles(axis_32, ang_32, Oh)
-        assert np.all(ori._symmetry[0] == C1)
-        assert np.all(ori._symmetry[1] == Oh)
-        degrees = Quaternion(qu_64).to_axes_angles(degrees=True)[1]
-        assert np.allclose(np.deg2rad(degrees), ax_64[:, 3], atol=4)
+
+    def test_qu2ax_negative_magnitude(self):
+        q = np.array([-0.1, 0.2, 0.3, 0.4])
+        ax = qu2ax_single.py_func(q)
+        assert np.allclose(ax, [-0.3714, -0.5571, -0.7428, 3.3419], atol=1e-4)
 
     def test_ho2ro(self, homochoric_vectors, rodrigues_vectors):
-        # single
-        for ho, ro in zip(homochoric_vectors, rodrigues_vectors):
+        ho_64 = homochoric_vectors
+        ro_64 = rodrigues_vectors
+
+        # Single
+        for ho, ro in zip(ho_64, ro_64):
             assert np.allclose(ho2ro_single.py_func(ho), ro, atol=1e-4)
-        # 2d
-        assert np.allclose(
-            ho2ro_2d.py_func(homochoric_vectors), rodrigues_vectors, atol=1e-4
-        )
-        # nd
-        assert np.allclose(ho2ro(homochoric_vectors), rodrigues_vectors, atol=1e-4)
-        # nd_float32
-        ho_32 = homochoric_vectors.astype(np.float32)
-        rod_32 = rodrigues_vectors.astype(np.float32)
-        assert np.allclose(ho2ro(ho_32), rod_32, atol=1e-4)
+
+        # 2D
+        assert np.allclose(ho2ro_2d.py_func(ho_64), ro_64, atol=1e-4)
+
+        # ND
+        ho_64_nd = ho_64.reshape((2, 5, 3))
+        ro_64_nd = ro_64.reshape((2, 5, 4))
+        assert np.allclose(ho2ro(ho_64_nd), ro_64_nd, atol=1e-4)
+
+        # ND float32
+        ho_32_nd = ho_64_nd.astype(np.float32)
+        rod_32_nd = ro_64_nd.astype(np.float32)
+        assert np.allclose(ho2ro(ho_32_nd), rod_32_nd, atol=1e-4)
 
     def test_cu2ro(self, cubochoric_coordinates, rodrigues_vectors):
-        # single
-        for cu, ro in zip(cubochoric_coordinates, rodrigues_vectors):
-            assert np.allclose(cu2ro_single.py_func(cu), ro, atol=1e-4)
-        # 2d
-        assert np.allclose(
-            cu2ro_2d.py_func(cubochoric_coordinates), rodrigues_vectors, atol=1e-4
-        )
-        # nd
-        assert np.allclose(cu2ro(cubochoric_coordinates), rodrigues_vectors, atol=1e-4)
-        # nd_float32
-        cub_32 = cubochoric_coordinates.astype(np.float32)
-        rod_32 = rodrigues_vectors.astype(np.float32)
-        assert np.allclose(cu2ro(cub_32), rod_32, atol=1e-4)
+        cu_64 = cubochoric_coordinates
+        ro_64 = rodrigues_vectors
 
-    def test_om2qu2om(self, orthogonal_matrices, quaternions_conversions):
-        # checks both om2qu and qu2om simultaneously
-        om_64 = orthogonal_matrices
+        # Single
+        for cu, ro in zip(cu_64, ro_64):
+            assert np.allclose(cu2ro_single.py_func(cu), ro, atol=1e-4)
+
+        # 2D
+        assert np.allclose(cu2ro_2d.py_func(cu_64), ro_64, atol=1e-4)
+
+        # ND
+        cu_64_nd = cu_64.reshape((2, 5, 3))
+        ro_64_nd = ro_64.reshape((2, 5, 4))
+        assert np.allclose(cu2ro(cu_64_nd), ro_64_nd, atol=1e-4)
+
+        # ND float32
+        cu_32_nd = cu_64_nd.astype(np.float32)
+        ro_32_nd = ro_64_nd.astype(np.float32)
+        assert np.allclose(cu2ro(cu_32_nd), ro_32_nd, atol=1e-4)
+
+    def test_om2qu2om(self, orientation_matrices, quaternions_conversions):
+        # Checks both om2qu and qu2om simultaneously
+        om_64 = orientation_matrices
         qu_64 = quaternions_conversions
-        om_32 = om_64.astype(np.float32)
-        qu_32 = qu_64.astype(np.float32)
-        # single
+
+        # Single
         for om, qu in zip(om_64, qu_64):
             assert np.allclose(om2qu_single.py_func(om), qu, atol=1e-4)
             assert np.allclose(qu2om_single.py_func(qu), om, atol=1e-4)
-        # test edge cases where q[0] is at or near zero
+
+        # Test edge cases where q[0] is at or near zero
         rot_pi_111 = np.array([[-1, 2, 2], [2, -1, 2], [2, 2, -1]]) / 3
         qu_from_om = om2qu_single.py_func(rot_pi_111)
         qu_actual = np.array([0, np.sqrt(1 / 3), np.sqrt(1 / 3), np.sqrt(1 / 3)])
         om_from_qu = qu2om_single.py_func(qu_actual)
         assert np.allclose(qu_from_om, qu_actual)
         assert np.allclose(om_from_qu, rot_pi_111)
-        # 2d
+
+        # 2D
         assert np.allclose(om2qu_3d.py_func(om_64), qu_64, atol=1e-4)
         assert np.allclose(om_64, qu2om_2d.py_func(qu_64), atol=1e-4)
-        # nd
-        assert np.allclose(om2qu(om_64), qu_64, atol=1e-4)
-        assert np.allclose(om_64, qu2om(qu_64), atol=1e-4)
-        # nd_float32
-        assert np.allclose(om2qu(om_32), qu_32, atol=1e-4)
-        assert np.allclose(om_32, qu2om(qu_32), atol=1e-4)
-        # Quaternion.from_matrix input checks
-        quat = Quaternion.from_matrix(om_64).data
-        assert np.allclose(quat, qu_64, atol=1e-4)
-        with pytest.raises(ValueError, match="(3, 3)"):
-            Quaternion.from_matrix(om_64[:, :, :2])
-        with pytest.raises(ValueError, match="(3, 3)"):
-            Quaternion.from_matrix(om_64[:, :2, :])
 
-    def test_qu2om(self, orthogonal_matrices, quaternions_conversions):
-        # single
-        for om, qu in zip(orthogonal_matrices, quaternions_conversions):
+        # ND
+        om_64_nd = om_64.reshape((2, 5, 3, 3))
+        qu_64_nd = qu_64.reshape((2, 5, 4))
+        assert np.allclose(om2qu(om_64_nd), qu_64_nd, atol=1e-4)
+        assert np.allclose(om_64_nd, qu2om(qu_64_nd), atol=1e-4)
+
+        # ND float32
+        om_32_nd = om_64_nd.astype(np.float32)
+        qu_32_nd = qu_64_nd.astype(np.float32)
+        assert np.allclose(om2qu(om_32_nd), qu_32_nd, atol=1e-4)
+        assert np.allclose(om_32_nd, qu2om(qu_32_nd), atol=1e-4)
+
+    def test_om2qu(self, orientation_matrices, quaternions_conversions):
+        om_64 = orientation_matrices
+        qu_64 = quaternions_conversions
+
+        # Single
+        for om, qu in zip(om_64, qu_64):
             assert np.allclose(om2qu_single.py_func(om), qu, atol=1e-4)
-        # test edge cases where q[0] is at or near zero
+
+        # Test edge cases where q[0] is at or near zero
         rot_pi_111 = np.array([[-1, 2, 2], [2, -1, 2], [2, 2, -1]]) / 3
         qu_from_om = om2qu_single.py_func(rot_pi_111)
         qu_actual = np.array([0, np.sqrt(1 / 3), np.sqrt(1 / 3), np.sqrt(1 / 3)])
         assert np.allclose(qu_from_om, qu_actual)
-        # 2d
-        assert np.allclose(
-            om2qu_3d.py_func(orthogonal_matrices), quaternions_conversions, atol=1e-4
-        )
-        # nd
-        assert np.allclose(
-            om2qu(orthogonal_matrices), quaternions_conversions, atol=1e-4
-        )
-        # nd_float32
-        om_32 = orthogonal_matrices.astype(np.float32)
-        qu_32 = quaternions_conversions.astype(np.float32)
-        assert np.allclose(om2qu(om_32), qu_32, atol=1e-4)
 
-    def test_quaternion_shortcuts(
-        self, rodrigues_vectors, homochoric_vectors, quaternions_conversions
-    ):
-        """These functions should evenutally be added to _conversions.py,
-        but are currently done with shortcut functions in the Quaternion
-        Class that use Quaternion.axis and Quaternion.angle."""
-        quat = Quaternion(quaternions_conversions[3:])
-        quat_hom = quat.to_homochoric().data
-        quat_rod = quat.to_rodrigues().data
-        hom_3 = homochoric_vectors[3:]
-        rod_3 = rodrigues_vectors[3:, :3] * rodrigues_vectors[3:, 3:]
-        assert np.allclose(hom_3, quat_hom, atol=1e-4)
-        assert np.allclose(rod_3, quat_rod, atol=2e-3)
+        # 2D
+        assert np.allclose(om2qu_3d.py_func(om_64), qu_64, atol=1e-4)
+
+        # ND
+        om_64_nd = om_64.reshape((2, 5, 3, 3))
+        qu_64_nd = qu_64.reshape((2, 5, 4))
+        assert np.allclose(om2qu(om_64_nd), qu_64_nd, atol=1e-4)
+
+        # ND float32
+        om_32_nd = om_64_nd.astype(np.float32)
+        qu_32_nd = qu_64_nd.astype(np.float32)
+        assert np.allclose(om2qu(om_32_nd), qu_32_nd, atol=1e-4)
+
+    def test_qu2ho(self, quaternions_conversions, homochoric_vectors):
+        qu_64 = quaternions_conversions
+        ho_64 = homochoric_vectors
+
+        # Single
+        for qu, ho in zip(qu_64, ho_64):
+            assert np.allclose(qu2ho_single.py_func(qu), ho, atol=1e-4)
+
+        # 2D
+        assert np.allclose(qu2ho_2d.py_func(qu_64), ho_64, atol=1e-4)
+
+        # ND
+        qu_64_nd = qu_64.reshape((2, 5, 4))
+        ho_64_nd = ho_64.reshape((2, 5, 3))
+        assert np.allclose(qu2ho(qu_64_nd), ho_64_nd, atol=1e-4)
+
+        # ND float32
+        qu_32_nd = qu_64_nd.astype(np.float32)
+        ho_32_nd = ho_64_nd.astype(np.float32)
+        assert np.allclose(qu2ho(qu_32_nd), ho_32_nd, atol=1e-4)
+
+        with pytest.raises(
+            ValueError, match="Final dimension of quaternion array must be 4"
+        ):
+            qu2ho(qu_32_nd[..., :3])
+
+    def test_qu2ho2ax2qu(self, quaternions_conversions):
+        qu1 = quaternions_conversions
+        ho = qu2ho(qu1)
+        ax = ho2ax(ho)
+        qu2 = ax2qu(ax[..., :3], ax[..., 3])
+        assert np.allclose(qu1, qu2, atol=1e-3)  # 1e-4 errors

--- a/orix/tests/quaternion/test_orientation.py
+++ b/orix/tests/quaternion/test_orientation.py
@@ -498,10 +498,12 @@ class TestOrientationInitialization:
 
     def test_from_neo_euler_symmetry(self):
         v = AxAngle.from_axes_angles(axes=Vector3d.zvector(), angles=np.pi / 2)
-        o1 = Orientation.from_neo_euler(v)
+        with pytest.warns(np.VisibleDeprecationWarning):
+            o1 = Orientation.from_neo_euler(v)
         assert np.allclose(o1.data, [0.7071, 0, 0, 0.7071])
         assert o1.symmetry.name == "1"
-        o2 = Orientation.from_neo_euler(v, symmetry=Oh)
+        with pytest.warns(np.VisibleDeprecationWarning):
+            o2 = Orientation.from_neo_euler(v, symmetry=Oh)
         o2 = o2.map_into_symmetry_reduced_zone()
         assert np.allclose(o2.data, [-1, 0, 0, 0])
         assert o2.symmetry.name == "m-3m"

--- a/orix/tests/quaternion/test_orientation_region.py
+++ b/orix/tests/quaternion/test_orientation_region.py
@@ -119,14 +119,12 @@ def test_get_distinguished_points(s1, s2, expected):
 )
 def test_get_large_cell_normals(s1, s2, expected):
     n = _get_large_cell_normals(s1, s2)
-    print(n)
     assert np.allclose(n.data, expected, atol=1e-3)
 
 
 def test_coverage_on_faces():
     o = OrientationRegion(Orientation([1, 1, 1, 1]))
-    f = o.faces()
-    return None
+    _ = o.faces()
 
 
 @pytest.mark.parametrize(
@@ -143,11 +141,10 @@ def test_coverage_on_faces():
     ],
 )
 def test_get_proper_point_groups(Gl, Gr):
-    get_proper_groups(Gl, Gr)
-    return None
+    _ = get_proper_groups(Gl, Gr)
 
 
 def test_get_proper_point_group_not_implemented():
-    """Double inversion case not yet implemented"""
+    """Double inversion case not yet implemented."""
     with pytest.raises(NotImplementedError):
         _ = get_proper_groups(Csz, Csz)

--- a/orix/vector/neo_euler.py
+++ b/orix/vector/neo_euler.py
@@ -59,11 +59,11 @@ class NeoEuler(Vector3d, abc.ABC):
 
 
 class Homochoric(NeoEuler):
-    """Equal-volume mapping of the unit quaternion hemisphere.
+    r"""Equal-volume mapping of the unit quaternion hemisphere.
 
     The homochoric vector representing a rotation with rotation angle
-    :math:`\\theta` has magnitude
-    :math:`\\left[\\frac{3}{4}(\\theta - \\sin\\theta)\\right]^{\\frac{1}{3}}`.
+    :math:`\theta` has magnitude
+    :math:`\left[\frac{3}{4}(\theta - \sin\theta)\right]^{\frac{1}{3}}`.
 
     Notes
     -----
@@ -85,9 +85,8 @@ class Homochoric(NeoEuler):
             Homochoric vector.
         """
         theta = rotation.angle
-        n = rotation.axis
         magnitude = (0.75 * (theta - np.sin(theta))) ** (1 / 3)
-        return cls(n * magnitude)
+        return cls(rotation.axis * magnitude)
 
     @property
     def angle(self):
@@ -134,10 +133,10 @@ class Rodrigues(NeoEuler):
 
 
 class AxAngle(NeoEuler):
-    """The simplest neo-Eulerian representation.
+    r"""The simplest neo-Eulerian representation.
 
-    The Axis-Angle vector representing a rotation with rotation angle
-    :math:`\\theta` has magnitude :math:`\\theta`
+    The axis-angle vector representing a rotation with rotation angle
+    :math:`\theta` has magnitude :math:`\theta`.
     """
 
     @classmethod

--- a/orix/vector/neo_euler.py
+++ b/orix/vector/neo_euler.py
@@ -83,6 +83,10 @@ class Homochoric(NeoEuler):
         -------
         vec
             Homochoric vector.
+
+        See Also
+        --------
+        Quaternion.to_homochoric
         """
         theta = rotation.angle
         magnitude = (0.75 * (theta - np.sin(theta))) ** (1 / 3)
@@ -118,6 +122,10 @@ class Rodrigues(NeoEuler):
         -------
         vec
             Rodrigues vector.
+
+        See Also
+        --------
+        Quaternion.to_rodrigues
         """
         a = np.float64(rotation.a)
         with np.errstate(divide="ignore", invalid="ignore"):
@@ -152,6 +160,10 @@ class AxAngle(NeoEuler):
         -------
         vec
             Axis-angle representation of ``rotation``.
+
+        See Also
+        --------
+        Quaternion.to_axes_angles
         """
         return cls((rotation.axis * rotation.angle).data)
 

--- a/orix/vector/vector3d.py
+++ b/orix/vector/vector3d.py
@@ -609,11 +609,11 @@ class Vector3d(Object3d):
         """
         # Import here to avoid circular import
         from orix.quaternion import Rotation
-        from orix.vector.neo_euler import AxAngle
 
         axis = Vector3d.zvector() if axis is None else axis
         angle = 0 if angle is None else angle
         q = Rotation.from_axes_angles(axis, angle)
+
         return q * self
 
     def get_nearest(


### PR DESCRIPTION
#### Description of the change
Following up on https://github.com/pyxem/orix/pull/450#issuecomment-1626138989.

Things left for another PR:
* Overwrite these methods in relevant classes (Rotation, Orientation, Misorientation).

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### Minimal example of the bug fix or new feature
```python
>>> from orix.quaternion import Quaternion
>>> q = Quaternion.from_axes_angles([1, 1, 1], 120, degrees=True)
>>> q
Quaternion (1,)
[[0.5 0.5 0.5 0.5]]
>>> q.to_axes_angles()
AxAngle (1,)
[[1.2092 1.2092 1.2092]]
>>> q.to_rodrigues()
Rodrigues (1,)
[[1. 1. 1.]]
>>> q.to_rodrigues(frank=True)
array([[0.57735027, 0.57735027, 0.57735027, 1.73205081]])
>>> q.to_homochoric()
Homochoric (1,)
[[0.5618 0.5618 0.5618]]
```

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.